### PR TITLE
Add repository onboarding and UI definition docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,60 @@
+name: Bug report
+description: Report broken or incorrect behavior.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug.
+
+        Bug-fix work in this repository is expected to link back to an issue like this one.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction steps
+      description: How can someone reproduce the problem?
+      placeholder: |
+        1. Open ...
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS
+        - iOS
+        - Android
+        - Linux
+        - Windows
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Logs, traces, or screenshots
+      description: Include any useful traces, audio notes, or screenshots.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Support
+    url: https://github.com/kellyjanderson/readaloud/blob/main/SUPPORT.md
+    about: Read setup and support guidance before opening an issue.
+  - name: Security policy
+    url: https://github.com/kellyjanderson/readaloud/blob/main/SECURITY.md
+    about: Do not report security problems in public issues.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Propose a new capability or enhancement.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a feature.
+
+        Feature implementation in this repository should be tied to a specification.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or need
+      description: What problem should this feature solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed feature
+      description: What should happen?
+    validations:
+      required: true
+  - type: textarea
+    id: spec
+    attributes:
+      label: Related specification
+      description: Link an existing spec, or describe what spec should be created first.
+      placeholder: project/specifications/...
+  - type: textarea
+    id: success
+    attributes:
+      label: Success criteria
+      description: What would make this feature complete?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Summary
+
+Describe the change clearly and briefly.
+
+## Change Type
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Docs only
+- [ ] Maintenance
+
+## Required Linkage
+
+- Issue:
+- Specification:
+
+Bug-fix branches should link to an issue.
+
+Feature branches should link to a specification.
+
+## Validation
+
+- [ ] `flutter analyze`
+- [ ] `flutter test`
+- [ ] relevant manual validation completed
+- [ ] speech/audio verification completed when relevant
+
+## Notes
+
+Anything reviewers or future readers should know.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Code Of Conduct
+
+This project aims to be direct, kind, and collaborative.
+
+## Our Standard
+
+People participating in this project should:
+
+- treat each other with respect
+- assume good intent while still giving honest feedback
+- criticize ideas and implementations without attacking people
+- keep discussions constructive, concrete, and relevant to the work
+- help keep the project welcoming to contributors with different backgrounds and experience levels
+
+Unacceptable behavior includes:
+
+- harassment or intimidation
+- personal attacks
+- discriminatory language or conduct
+- bad-faith disruption
+- publishing private information without permission
+
+## Scope
+
+This applies to repository discussions, issues, pull requests, reviews, and other project spaces.
+
+## Enforcement
+
+Project maintainers may remove, edit, or reject contributions and interactions that do not align with this code of conduct.
+
+## Reporting
+
+If you need to report a conduct problem, use the contact path in:
+
+- [`SUPPORT.md`](SUPPORT.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing To Read Aloud
+
+Thanks for contributing.
+
+## Before You Start
+
+Read:
+
+- [`README.md`](README.md)
+- [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+- [`SECURITY.md`](SECURITY.md)
+- [`agents/git-and-github.md`](agents/git-and-github.md)
+- [`project/README.md`](project/README.md)
+
+## Branch Rules
+
+Do not make implementation changes directly on `main`.
+
+Use:
+
+- `bugfix/<issue-id>-<short-description>` for defect work
+- `feature/<short-spec-slug>` for feature work
+
+Bug-fix branches must link to an issue.
+
+Feature branches must link to a specification.
+
+## Pull Requests
+
+All branch work should land through a pull request.
+
+For the current team shape:
+
+- pull requests are still required
+- formal review is not required
+- anyone may merge the pull request
+
+## Local Setup
+
+1. Install Flutter `3.41.5`.
+2. Run `flutter pub get`.
+3. Place the Kokoro model file at:
+
+```text
+assets/kokoro/model/kokoro-v1.0.onnx
+```
+
+Model setup notes:
+
+- [`assets/kokoro/model/README.md`](assets/kokoro/model/README.md)
+
+## Running
+
+macOS is the only currently validated target.
+
+```bash
+flutter run -d macos
+```
+
+## Validation
+
+At minimum, use the checks relevant to your change:
+
+```bash
+flutter analyze
+flutter test
+```
+
+For pronunciation, synthesis, and speech-quality changes, follow the project audio-verification rule in:
+
+- [`project/agents/README.md`](project/agents/README.md)
+
+Do not call a speech fix successful if the emitted audio did not materially change or if that verification was not performed.
+
+## Docs And Specs
+
+This repository uses durable product and system documents.
+
+Relevant folders:
+
+- [`project/architecture/`](project/architecture/)
+- [`project/specifications/`](project/specifications/)
+- [`project/planning/`](project/planning/)
+- [`project/research/`](project/research/)
+
+If your work changes behavior, update the relevant durable docs alongside the implementation.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,127 @@
 # Read Aloud
 
-`Read Aloud` is a Flutter-based document reader that opens documents and reads them aloud with a
-local-first speech pipeline.
+`Read Aloud` is a local-first Flutter document reader focused on high-quality long-form text-to-speech.
 
-## Documentation
+The current repository contains the new Kokoro-based speech pipeline, document import and normalization, pronunciation planning and diagnostics, export and headless QA tooling, and the full architecture/specification corpus for the project.
 
-Project-level documentation now lives under [project/README.md](project/README.md).
+## Status
 
-Start there for:
+- current release target: `Beta 2`
+- platform status: macOS is the only platform currently treated as functional
+- other Flutter targets may build, but have not been validated yet
 
-- architecture
-- specifications
-- planning
-- research
+## What It Does
 
-Legacy root planning documents remain only as pointers into `project/`.
+- opens and normalizes imported documents
+- reads them aloud through a local speech pipeline
+- supports playback progress, jumping, and export
+- traces pronunciation and synthesis behavior for debugging
+- provides probe and sentence-by-sentence QA workflows for speech evaluation
+
+## Repository Layout
+
+- [`lib/`](lib/) application code
+- [`assets/`](assets/) bundled pronunciation resources and Kokoro voice assets
+- [`project/`](project/) product, architecture, specifications, planning, and research
+- [`test/`](test/) regression and behavior tests
+- [`third_party/`](third_party/) vendored third-party source and license material
+
+Project system documentation starts in [`project/README.md`](project/README.md).
+
+## Prerequisites
+
+- Flutter `3.41.5`
+- Dart `3.11.3`
+- Xcode and CocoaPods for macOS and iOS work
+- Git LFS is not required for a normal clone of this repository as currently checked in
+
+## External Model Dependency
+
+The Kokoro ONNX model is not committed to this repository.
+
+Before running or building the app, place a compatible model file at:
+
+```text
+assets/kokoro/model/kokoro-v1.0.onnx
+```
+
+Setup notes live in:
+
+- [`assets/kokoro/model/README.md`](assets/kokoro/model/README.md)
+
+Without that file, Kokoro-backed speech startup will fail because the Flutter asset bundle expects that model path to exist.
+
+## Quick Start
+
+```bash
+git clone https://github.com/kellyjanderson/readaloud.git
+cd readaloud
+flutter pub get
+```
+
+Then download or place the Kokoro model file at:
+
+```text
+assets/kokoro/model/kokoro-v1.0.onnx
+```
+
+Run the macOS app:
+
+```bash
+flutter run -d macos
+```
+
+Build the macOS app:
+
+```bash
+flutter build macos
+```
+
+## Development Notes
+
+- the repository currently uses a local `dependency_overrides` path for [`third_party/flutter_onnxruntime`](third_party/flutter_onnxruntime)
+- Kokoro voice `.npy` files and pronunciation resources are checked in
+- generated local speech QA artifacts are ignored under [`project/test-artifacts/`](project/test-artifacts)
+
+## Testing
+
+Examples:
+
+```bash
+flutter test
+flutter analyze
+```
+
+Speech-quality work should also use the in-repo probe and trace workflows rather than relying only on manual listening. Project-specific agent rules for that live in:
+
+- [`project/agents/README.md`](project/agents/README.md)
+
+## Contributing
+
+Start here:
+
+- [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+- [`SECURITY.md`](SECURITY.md)
+- [`SUPPORT.md`](SUPPORT.md)
+
+Branch and pull request workflow rules are defined in:
+
+- [`agents/git-and-github.md`](agents/git-and-github.md)
+
+## Community Standards
+
+- bugs should be filed through GitHub issues
+- feature work should be tied to a specification
+- bug-fix work should be tied to an issue
+- implementation work should happen on branches, not directly on `main`
+- pull requests are required, even though formal review is not currently required for this repo
+
+## License And Third-Party Notes
+
+The repository includes third-party code and license material under [`third_party/`](third_party/) and supporting notes in:
+
+- [`project/research/open-source-licensing-notes.md`](project/research/open-source-licensing-notes.md)
+- [`OPEN_SOURCE_LICENSING_PLAN.md`](OPEN_SOURCE_LICENSING_PLAN.md)
+
+A top-level project license has not yet been added in this pass.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Status
+
+`Read Aloud` is currently in beta and only macOS is treated as functionally validated.
+
+## Reporting A Vulnerability
+
+Please do not open a public GitHub issue for a suspected security vulnerability.
+
+Instead:
+
+1. prepare a clear report with affected area, reproduction details, impact, and any proof-of-concept material
+2. open a private security advisory or contact the maintainer directly through the repository owner contact path
+
+When a private reporting path is not available, use the repository owner contact associated with:
+
+- `kellyjanderson/readaloud`
+
+## What To Include
+
+- affected component
+- environment and platform
+- reproduction steps
+- impact assessment
+- any suggested remediation
+
+## Response Expectations
+
+This repository does not currently publish formal SLA targets, but good-faith reports should be acknowledged and triaged as quickly as practical.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,25 @@
+# Support
+
+## Getting Help
+
+Use GitHub issues for:
+
+- bug reports
+- feature requests
+- documentation gaps
+- setup problems that are specific to this repository
+
+Before opening an issue, check:
+
+- [`README.md`](README.md)
+- [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- [`assets/kokoro/model/README.md`](assets/kokoro/model/README.md)
+- [`project/README.md`](project/README.md)
+
+## Security
+
+Do not use public issues for security reports.
+
+Use:
+
+- [`SECURITY.md`](SECURITY.md)

--- a/agents/index.md
+++ b/agents/index.md
@@ -11,6 +11,9 @@ Start here before taking action.
 * **architecture.md**
   Defines what architecture documents are and how they describe system structure and cross-domain solutions.
 
+* **ui-definitions.md**
+  Defines the interface-structure layer that captures durable visible behavior and interaction semantics.
+
 * **specifications.md**
   Defines how architecture is refined into implementable specification units.
 
@@ -35,6 +38,7 @@ Project-level documents live in:
 ```text
 project/
   agents/
+  ui/
   product-definition.md
   architecture/
   specifications/
@@ -61,8 +65,9 @@ When beginning work:
 1. review `project/product-definition.md` (if present)
 2. review `project/agents/` for project-specific operating rules
 3. review `git-and-github.md` before implementation work
-4. review relevant architecture
-5. follow the workflow defined in `workflow.md`
+4. review relevant UI definitions
+5. review relevant architecture
+6. follow the workflow defined in `workflow.md`
 
 ---
 

--- a/agents/ui-definitions.md
+++ b/agents/ui-definitions.md
@@ -1,0 +1,89 @@
+# UI Definition Guidance
+
+UI definitions are the visible-behavior analog to system architecture.
+
+They define the durable structure of the interface and interaction model without dropping immediately into implementation detail.
+
+---
+
+## Purpose
+
+UI definitions exist to describe:
+
+* what interface surfaces exist
+* which controls are primary
+* how complexity is layered
+* what interaction states mean
+* how status is communicated
+* how appearance modes and navigation patterns should work
+
+They should capture durable design intent, not transient implementation detail.
+
+---
+
+## When To Use UI Definitions
+
+Use UI definitions when the question is primarily about visible behavior, interaction structure, or interface semantics.
+
+Examples:
+
+* top-level vs secondary controls
+* where advanced features should live
+* what a disabled-but-communicating control should look like
+* how themes and appearance modes should work
+* how a live mode should behave from the user's perspective
+* what persistent affordances should exist across screens
+
+If the problem is about system structure, use architecture.
+
+If the problem is about exact implementation rules, thresholds, or acceptance criteria, use specifications.
+
+---
+
+## Recommended Structure
+
+UI definition documents should generally include:
+
+### Overview
+
+A short description of the interface area or UI concept.
+
+### Primary Interface Elements
+
+What should be visible and dominant on the primary surface.
+
+### Secondary Access
+
+How advanced or less frequent actions are accessed without cluttering the main interface.
+
+### States And Semantics
+
+The meaning of visible states, control conditions, and status communication.
+
+### Appearance And Accessibility
+
+Theme behavior, contrast requirements, and other durable visual rules.
+
+### Related Specifications
+
+References to narrower specifications that implement parts of the UI definition.
+
+---
+
+## Relationship To Architecture
+
+Architecture defines invisible system structure.
+
+UI definitions define visible interaction structure.
+
+Both sit above specifications and should stabilize before detailed implementation work begins in their area.
+
+Specifications should refine a coherent UI definition rather than inventing interface behavior ad hoc during implementation.
+
+---
+
+## Stability
+
+UI definitions should change less often than implementation-level specifications.
+
+They are intended to preserve coherent interface behavior across multiple implementation rounds.

--- a/agents/workflow.md
+++ b/agents/workflow.md
@@ -30,6 +30,18 @@ agents/git-and-github.md
 
 Agents should satisfy those branch and PR requirements before making code changes.
 
+UI definition guidance is defined in:
+
+```text
+agents/ui-definitions.md
+```
+
+Project UI definition documents should live in:
+
+```text
+project/ui/
+```
+
 ---
 
 ## Exploration Loops
@@ -50,6 +62,29 @@ project/product-definition.md
 * update the product definition as needed
 
 This loop continues until the product definition is sufficiently clear.
+
+---
+
+### UI Definitions ↔ Research
+
+UI definitions are refined through research and observation.
+
+Primary UI definition documents live in:
+
+```text
+project/ui/
+```
+
+* identify interface unknowns, clutter, ambiguity, or interaction problems
+* perform research or observation where needed
+* store findings in the research folder when they are durable
+* update UI definitions to reflect resolved interaction structure
+
+This loop continues until the relevant UI surface is sufficiently coherent.
+
+UI definition work is breadth first across the relevant interface area.
+
+The goal is to define the visible structure and interaction semantics of the surface before narrower specifications or implementation details are finalized.
 
 ---
 
@@ -77,6 +112,7 @@ The goal is to understand how the parts work together at system level, not to fu
 At some point:
 
 * product definition becomes stable enough to guide development
+* UI definitions become stable enough to guide interface work
 * architecture becomes stable enough to define system structure
 
 For architecture, "stable enough" means the relevant architecture documents for the area of work have been completed breadth first.
@@ -103,11 +139,12 @@ After stabilization:
 * break architecture into specifications
 * evaluate each specification for implementability
 
-Specifications are written only after the relevant architecture documents are complete enough to describe the whole system area being refined.
+Specifications are written only after the relevant architecture and UI definition documents are complete enough to describe the whole system area being refined.
 
-Architecture comes first.
+Architecture and UI definitions come first for their respective concerns.
 
 Specification refinement is not a substitute for unfinished architecture work.
+It is also not a substitute for unfinished UI definition work when the interface structure itself is still unclear.
 
 For each specification:
 
@@ -199,11 +236,13 @@ If specifications change during execution:
 If implementation reveals issues that affect:
 
 * product definition, or
+* UI definition, or
 * system structure
 
 return to the appropriate loop:
 
 * product ↔ research
+* UI definitions ↔ research
 * architecture ↔ research
 
 Update documents before continuing.

--- a/assets/kokoro/model/README.md
+++ b/assets/kokoro/model/README.md
@@ -1,0 +1,34 @@
+# Kokoro Model Setup
+
+This directory is intentionally kept out of normal git history for the ONNX model file.
+
+The app expects this exact file path before build or run:
+
+```text
+assets/kokoro/model/kokoro-v1.0.onnx
+```
+
+## Suggested Sources
+
+Use a compatible Kokoro ONNX model from a trusted upstream source such as:
+
+- `thewh1teagle/kokoro-onnx` releases
+- `hexgrad/Kokoro-82M`
+
+Reference pages:
+
+- https://github.com/thewh1teagle/kokoro-onnx/releases
+- https://huggingface.co/hexgrad/Kokoro-82M
+
+## Required Local Result
+
+After download, the repository should contain:
+
+```text
+assets/
+  kokoro/
+    model/
+      kokoro-v1.0.onnx
+```
+
+Do not commit the ONNX file to normal git history.

--- a/project/README.md
+++ b/project/README.md
@@ -2,9 +2,10 @@
 
 This directory is the authoritative source of project understanding for `Read Aloud`.
 
-The documentation is organized around a product definition plus five supporting domains:
+The documentation is organized around a product definition plus six supporting domains:
 
 - `agents/`: project-specific agent operating rules
+- `ui/`: interface structure, interaction semantics, complexity layering, and durable visual behavior
 - `product-definition.md`: feature definition, user expectations, scope, and non-goals
 - `architecture/`: structural truth, boundaries, responsibilities, and data flow
 - `specifications/`: behavioral contracts, rules, thresholds, and acceptance criteria
@@ -16,6 +17,15 @@ The documentation is organized around a product definition plus five supporting 
 ### Agents
 
 - [Project Agent Rules](agents/README.md)
+
+### UI Definitions
+
+- [UI Definitions Index](ui/README.md)
+- [UI System Overview](ui/ui-system-overview.md)
+- [Primary Surface and Complexity Layering](ui/primary-surface-and-complexity-layering.md)
+- [Control State Semantics](ui/control-state-semantics.md)
+- [Theme and Appearance Modes](ui/theme-and-appearance-modes.md)
+- [Live Input and File Menu Behavior](ui/live-input-and-file-menu-behavior.md)
 
 ### Product
 

--- a/project/planning/progression.md
+++ b/project/planning/progression.md
@@ -120,6 +120,7 @@ It includes only leaf specifications that are marked final.
 
 - [x] [Playback Quality Instrumentation](../specifications/playback-quality-instrumentation.md)
 - [x] [Pronunciation Diagnostics and Observability](../specifications/pronunciation-diagnostics-and-observability.md)
+- [x] [Repository Readme and GitHub Community Files](../specifications/repository-readme-and-github-community-files.md)
 - [x] [Audio Export Assembly](../specifications/audio-export-assembly.md)
 - [x] [Command-Line Mode Selection](../specifications/command-line-mode-selection.md)
 - [x] [Headless Synthesis Session](../specifications/headless-synthesis-session.md)

--- a/project/specifications/README.md
+++ b/project/specifications/README.md
@@ -188,6 +188,11 @@ They are intentionally narrower than architecture documents. For any architectur
 - [Reader Session Continuity and Live Input](reader-session-continuity-and-live-input.md)
   Defines remembered file-backed reader state and watched-file live input behavior inside the running app.
 
+### Repository Onboarding and Community
+
+- [Repository Readme and GitHub Community Files](repository-readme-and-github-community-files.md)
+  Defines the required root onboarding docs and GitHub community-health files for the repository surface.
+
 ### Audio Export and Headless Execution
 
 - [Audio Export and Headless Execution](audio-export-and-headless-execution.md)

--- a/project/specifications/repository-readme-and-github-community-files.md
+++ b/project/specifications/repository-readme-and-github-community-files.md
@@ -1,0 +1,60 @@
+# Repository Readme And GitHub Community Files
+
+Status: final
+
+## Purpose
+
+Define the required repository-facing onboarding and community-health files that make the project understandable and operable from the GitHub surface.
+
+## Requirements
+
+The repository must include a root `README.md` that:
+
+- explains what `Read Aloud` is
+- states current release or beta status
+- states current platform validation status
+- documents local setup and build entrypoints
+- explains the external Kokoro model dependency and required local file path
+- links to project architecture, specification, planning, and research docs
+- links to contribution and community guidance
+
+The repository must include contributor-facing community files:
+
+- `CONTRIBUTING.md`
+- `CODE_OF_CONDUCT.md`
+- `SECURITY.md`
+- `SUPPORT.md`
+
+The repository must include GitHub workflow surface files:
+
+- issue templates for bugs and feature requests
+- a pull request template
+
+## Branch And Workflow Alignment
+
+Contributor guidance must reflect the repository branch policy:
+
+- bug-fix work is issue-linked
+- feature work is specification-linked
+- implementation work should not proceed directly on `main`
+- pull requests are required even when formal review is not
+
+## External Model Dependency
+
+Because the Kokoro ONNX model is treated as an external dependency rather than a normal checked-in source asset, the repository must include durable setup guidance describing:
+
+- the required filename
+- the required local path
+- that the model should not be committed to normal git history
+- trusted or intended upstream source locations
+
+## Visibility Goal
+
+A new collaborator landing on the GitHub repository page should be able to answer:
+
+- what this project is
+- what platforms are currently supported
+- how to build it
+- how to obtain the missing model dependency
+- how to contribute correctly
+- how to file bugs or feature requests

--- a/project/ui/README.md
+++ b/project/ui/README.md
@@ -1,0 +1,31 @@
+# UI Definitions
+
+This folder is the durable source of truth for `Read Aloud` interface structure and interaction semantics.
+
+UI definitions are the visible-behavior analog to system architecture.
+
+They define:
+
+- what belongs on the primary interface
+- how complexity is layered
+- what control states mean
+- how status is communicated
+- how theming and appearance modes work
+- where advanced features should live
+
+## Current Documents
+
+- [UI System Overview](ui-system-overview.md)
+- [Primary Surface and Complexity Layering](primary-surface-and-complexity-layering.md)
+- [Control State Semantics](control-state-semantics.md)
+- [Theme and Appearance Modes](theme-and-appearance-modes.md)
+- [Live Input and File Menu Behavior](live-input-and-file-menu-behavior.md)
+
+## Relationship To Other Project Docs
+
+- `product-definition.md` defines what the product is for
+- `ui/` defines how the interface should behave and feel
+- `architecture/` defines invisible system structure
+- `specifications/` define narrower implementable contracts
+
+UI definitions should stay durable and coherent across multiple implementation rounds.

--- a/project/ui/control-state-semantics.md
+++ b/project/ui/control-state-semantics.md
@@ -1,0 +1,53 @@
+# Control State Semantics
+
+Controls in `Read Aloud` should use explicit semantic states rather than ad hoc visual treatment.
+
+## Core States
+
+There are currently three important control states:
+
+- active
+- inactive
+- inactive but communicating
+
+## Active
+
+An active control:
+
+- accepts interaction
+- presents normal emphasis for its role
+- does not need a special communicating treatment
+
+## Inactive
+
+An inactive control:
+
+- does not accept interaction
+- is visually muted
+- is not actively communicating ongoing work or state transition
+
+## Inactive But Communicating
+
+An inactive-but-communicating control:
+
+- does not accept interaction
+- remains visually muted at the control-body level
+- continues to communicate status through its icon or indicator
+
+The communicating icon or indicator must maintain high contrast against the muted control background.
+
+For this state, the icon or indicator should use whichever of black or white produces the strongest contrast against the selected grey background.
+
+## Current Known Case
+
+The known current case is the play control after the user presses play but before audio is actually produced.
+
+During that interval:
+
+- the button is not clickable
+- the button is still communicating work in progress
+- the communicating glyph should remain high contrast
+
+Related issue:
+
+- [GitHub Issue #1](https://github.com/kellyjanderson/readaloud/issues/1)

--- a/project/ui/live-input-and-file-menu-behavior.md
+++ b/project/ui/live-input-and-file-menu-behavior.md
@@ -1,0 +1,34 @@
+# Live Input And File Menu Behavior
+
+Live file watching is useful, but it should not consume a full top-level control on the primary reading surface.
+
+## Placement
+
+Live file watching should be accessed from the File menu rather than a dedicated persistent primary-surface button.
+
+## Behavioral Goal
+
+Live mode should feel truly live.
+
+When live mode is enabled:
+
+- file changes should update the loaded document without reloading the app
+- if playback is currently in the playing state, newly loaded changes should continue to play automatically
+- playback should stop only when the user has explicitly placed the transport in the paused state
+
+## Pause Semantics
+
+Paused means paused by explicit user intent, not paused merely because the document updated.
+
+When the transport is paused:
+
+- live updates may still refresh the document
+- audio should not resume automatically
+
+When the transport is playing:
+
+- live updates should continue the live-reading experience automatically after refresh
+
+## Complexity Rule
+
+This is an advanced workflow feature and should therefore follow the menu-placement rule rather than occupy constant space on the main interface.

--- a/project/ui/primary-surface-and-complexity-layering.md
+++ b/project/ui/primary-surface-and-complexity-layering.md
@@ -1,0 +1,46 @@
+# Primary Surface And Complexity Layering
+
+The primary reading surface should expose only the controls required for normal reading.
+
+## Primary Interface Elements
+
+The primary interface should center on:
+
+- voice selection
+- play or pause
+- jump backward
+- jump forward
+- the selected or currently read text
+
+These are the top-level elements that should remain visually dominant.
+
+## Simplification Rule
+
+The primary surface currently exposes too much voice and feature complexity.
+
+The direction is to simplify that surface so it feels focused on reading rather than configuration.
+
+## Voice Selection
+
+Voice selection should remain accessible at top level, but the number of visibly competing options should be reduced.
+
+The primary surface should prefer one clear active voice control over an expanded cluster of prominent voice-management UI.
+
+## Secondary Access Pattern
+
+When a domain is already represented on the primary surface, deeper options for that domain should be accessed through a consistent iconographic affordance integrated into the control itself or the control group.
+
+This iconographic affordance is the standard path to secondary complexity.
+
+It should feel like:
+
+- advanced options for the control already in front of the user
+- not a separate competing button family
+
+## Menu Placement Rule
+
+Features that add top-level complexity without being part of normal reading flow should move into menus by default.
+
+Current example:
+
+- live file watching belongs in the File menu rather than as a persistent primary-surface button

--- a/project/ui/theme-and-appearance-modes.md
+++ b/project/ui/theme-and-appearance-modes.md
@@ -1,0 +1,29 @@
+# Theme And Appearance Modes
+
+`Read Aloud` should support explicit appearance modes rather than a fixed look.
+
+## Supported Modes
+
+The interface should support:
+
+- light mode
+- dark mode
+- follow system
+
+## Default
+
+Default behavior should be:
+
+- follow system
+
+## Semantics
+
+Follow system means the app adopts the operating system appearance mode automatically.
+
+Light and dark modes should act as explicit overrides.
+
+## UI Placement
+
+Theme selection is not a primary reading control.
+
+It should live in a lower-complexity settings path rather than competing with the core reading controls on the main surface.

--- a/project/ui/ui-system-overview.md
+++ b/project/ui/ui-system-overview.md
@@ -1,0 +1,42 @@
+# UI System Overview
+
+`Read Aloud` should present a clean, simple, reading-first interface.
+
+The top-level surface should emphasize the controls a user needs for normal reading and minimize visual competition from advanced features.
+
+## Top-Level Goal
+
+The primary interface should feel calm, direct, and low-friction.
+
+Complexity should exist, but it should be layered behind predictable access points instead of competing with core reading controls.
+
+## Primary Interface Principles
+
+- keep the main reading surface visually simple
+- keep the most common reading controls immediately available
+- avoid presenting domain complexity at the top level unless it is part of normal reading flow
+- make advanced options discoverable without making them visually dominant
+
+## Complexity Layering
+
+The interface should distinguish between:
+
+- primary controls for normal reading flow
+- secondary controls related to already visible UI domains
+- advanced or less frequent controls that should live in menus
+
+Default rule:
+
+- top-level complexity should move into the File menu or other menu surfaces when it is not part of normal continuous reading
+- second-level complexity for already surfaced controls should be accessed through a consistent iconographic affordance integrated into the control or control group
+
+## Current Direction
+
+The current direction for `Read Aloud` is:
+
+- simplify the top-level surface
+- reduce prominently displayed voice options
+- keep reading transport central
+- keep the current reading text visible and prominent
+- move live file watching out of the primary surface and into the File menu
+- make advanced control-specific behavior accessible through a consistent iconographic mechanism


### PR DESCRIPTION
## Summary
- Establishes the 0.3.0 planning baseline currently represented by this branch.
- Adds the repository onboarding and UI-definition docs at the bottom of the stack.
- This PR is the first step in the ordered 0.3.0 merge sequence.

## Validation
- Docs/process changes only.
