### PR TITLE
Move document identity out of the reading surface

### DIFF
--- a/lib/src/controllers/reader_controller.dart
+++ b/lib/src/controllers/reader_controller.dart
@@ -82,6 +82,7 @@ class ReaderController extends ChangeNotifier {
   double _fontScale = ReaderPreferences.defaultFontScale;
   String? _lastOpenedDocumentPath;
   String? _lastOpenedDirectoryPath;
+  String? _currentDocumentPath;
   String? _liveReadFilePath;
   StreamSubscription<FileSystemEvent>? _liveReadSubscription;
   Timer? _liveReadReloadDebounce;
@@ -169,6 +170,15 @@ class ReaderController extends ChangeNotifier {
   bool get canExportAudio => _ttsEngine is AudioExportCapable;
   String get suggestedAudioExportFileName =>
       _defaultAudioExportFileName(_document.title, _selectedVoiceId);
+  String get currentDocumentWindowLabel {
+    final currentPath = _currentDocumentPath;
+    if (currentPath != null && currentPath.trim().isNotEmpty) {
+      return p.basename(currentPath);
+    }
+    final title = _document.title.trim();
+    return title.isEmpty ? 'Untitled' : title;
+  }
+  String get windowTitle => 'Read Aloud - $currentDocumentWindowLabel';
 
   Duration? get sleepTimerRemaining {
     if (_sleepTimerEndsAt == null) return null;
@@ -906,6 +916,7 @@ class ReaderController extends ChangeNotifier {
       await _loadImportedBytes(
         fileName: fileName,
         bytes: Uint8List.fromList(bytes),
+        sourcePath: firstFile.path,
         successMessage: message,
       );
     } catch (error) {
@@ -930,7 +941,7 @@ class ReaderController extends ChangeNotifier {
       fileName: fileName,
       bytes: bytes,
     );
-    await _replaceDocument(imported);
+    await _replaceDocument(imported, sourcePath: sourcePath);
     await _rememberOpenedDocumentPath(sourcePath);
     if (successMessage != null) {
       _statusMessage = imported.wordCount == 0
@@ -943,9 +954,13 @@ class ReaderController extends ChangeNotifier {
   Future<void> _replaceDocument(
     ReaderDocument document, {
     String? statusMessage,
+    String? sourcePath,
   }) async {
     await _ttsEngine.stop();
     _document = document;
+    _currentDocumentPath = (sourcePath == null || sourcePath.trim().isEmpty)
+        ? null
+        : p.normalize(sourcePath.trim());
     _currentWordIndex = 0;
     _wordsPerSecond = 2.8;
     _isPlaying = false;
@@ -1178,6 +1193,7 @@ class ReaderController extends ChangeNotifier {
       );
       await _replaceDocument(
         imported,
+        sourcePath: sourcePath,
         statusMessage: initialLoad
             ? 'Live read connected to ${p.basename(sourcePath)}.'
             : 'Live read updated ${p.basename(sourcePath)}.',

--- a/lib/src/screens/read_aloud_screen.dart
+++ b/lib/src/screens/read_aloud_screen.dart
@@ -57,20 +57,14 @@ class _ReadAloudScreenState extends State<ReadAloudScreen> {
         final reader = _buildReader(context);
         final controls = _buildControls(context);
 
-        return Scaffold(
-          appBar: AppBar(
-            backgroundColor: Colors.transparent,
-            surfaceTintColor: Colors.transparent,
-            title: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Text('Read Aloud'),
-                Text(
-                  _controller.document.title,
-                  style: Theme.of(context).textTheme.bodySmall,
-                ),
-              ],
-            ),
+        return Title(
+          title: _controller.windowTitle,
+          color: Theme.of(context).colorScheme.primary,
+          child: Scaffold(
+            appBar: AppBar(
+              backgroundColor: Colors.transparent,
+              surfaceTintColor: Colors.transparent,
+              title: const Text('Read Aloud'),
             actions: [
               TextButton.icon(
                 onPressed: _controller.isImporting
@@ -111,9 +105,9 @@ class _ReadAloudScreenState extends State<ReadAloudScreen> {
               ),
             ],
           ),
-          body: SafeArea(
-            child: LayoutBuilder(
-              builder: (context, constraints) {
+            body: SafeArea(
+              child: LayoutBuilder(
+                builder: (context, constraints) {
                 final wide = constraints.maxWidth >= 980;
                 final useScrollableStackedLayout =
                     !wide &&
@@ -184,109 +178,110 @@ class _ReadAloudScreenState extends State<ReadAloudScreen> {
                   ),
                 );
 
-                return Padding(
-                  padding: const EdgeInsets.fromLTRB(20, 8, 20, 20),
-                  child: Column(
-                    children: [
-                      if (_controller.isInitializing)
-                        const LinearProgressIndicator(minHeight: 2),
-                      if (status != null) ...[
-                        const SizedBox(height: 12),
-                        Material(
-                          color: const Color(0xFFFFF4D6),
-                          borderRadius: BorderRadius.circular(16),
-                          child: ListTile(
-                            leading: const Icon(Icons.info_outline),
-                            title: Text(status),
-                            trailing: IconButton(
-                              onPressed: _controller.clearStatus,
-                              icon: const Icon(Icons.close),
+                  return Padding(
+                    padding: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+                    child: Column(
+                      children: [
+                        if (_controller.isInitializing)
+                          const LinearProgressIndicator(minHeight: 2),
+                        if (status != null) ...[
+                          const SizedBox(height: 12),
+                          Material(
+                            color: const Color(0xFFFFF4D6),
+                            borderRadius: BorderRadius.circular(16),
+                            child: ListTile(
+                              leading: const Icon(Icons.info_outline),
+                              title: Text(status),
+                              trailing: IconButton(
+                                onPressed: _controller.clearStatus,
+                                icon: const Icon(Icons.close),
+                              ),
                             ),
                           ),
-                        ),
+                        ],
+                        const SizedBox(height: 12),
+                        Expanded(child: intakeSurface),
                       ],
-                      const SizedBox(height: 12),
-                      Expanded(child: intakeSurface),
+                    ),
+                  );
+                },
+              ),
+            ),
+            bottomNavigationBar: Material(
+              color: const Color(0xFFF7F5EF),
+              elevation: 12,
+              child: SafeArea(
+                top: false,
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 10, 16, 10),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              voiceLabel,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          Text(
+                            '${_controller.currentWordIndex} / ${_controller.document.wordCount} words',
+                            style: Theme.of(context).textTheme.bodySmall,
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      Row(
+                        children: [
+                          IconButton.filledTonal(
+                            onPressed: transportEnabled
+                                ? () => _controller.jumpBySeconds(-30)
+                                : null,
+                            icon: const Icon(Icons.replay_30),
+                          ),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: FilledButton(
+                              style: isBuffering
+                                  ? FilledButton.styleFrom(
+                                      disabledBackgroundColor: Theme.of(
+                                        context,
+                                      ).colorScheme.primary,
+                                      disabledForegroundColor: Theme.of(
+                                        context,
+                                      ).colorScheme.onPrimary,
+                                    )
+                                  : null,
+                              onPressed: transportEnabled
+                                  ? _controller.togglePlayback
+                                  : null,
+                              child: AnimatedSwitcher(
+                                duration: const Duration(milliseconds: 180),
+                                child: isBuffering
+                                    ? const _LoadingDots(
+                                        key: ValueKey('buffering'),
+                                      )
+                                    : Icon(
+                                        _controller.isPlaying
+                                            ? Icons.pause
+                                            : Icons.play_arrow,
+                                        key: ValueKey(_controller.isPlaying),
+                                      ),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          IconButton.filledTonal(
+                            onPressed: transportEnabled
+                                ? () => _controller.jumpBySeconds(30)
+                                : null,
+                            icon: const Icon(Icons.forward_30),
+                          ),
+                        ],
+                      ),
                     ],
                   ),
-                );
-              },
-            ),
-          ),
-          bottomNavigationBar: Material(
-            color: const Color(0xFFF7F5EF),
-            elevation: 12,
-            child: SafeArea(
-              top: false,
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(16, 10, 16, 10),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Row(
-                      children: [
-                        Expanded(
-                          child: Text(
-                            voiceLabel,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                        Text(
-                          '${_controller.currentWordIndex} / ${_controller.document.wordCount} words',
-                          style: Theme.of(context).textTheme.bodySmall,
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 8),
-                    Row(
-                      children: [
-                        IconButton.filledTonal(
-                          onPressed: transportEnabled
-                              ? () => _controller.jumpBySeconds(-30)
-                              : null,
-                          icon: const Icon(Icons.replay_30),
-                        ),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: FilledButton(
-                            style: isBuffering
-                                ? FilledButton.styleFrom(
-                                    disabledBackgroundColor: Theme.of(
-                                      context,
-                                    ).colorScheme.primary,
-                                    disabledForegroundColor: Theme.of(
-                                      context,
-                                    ).colorScheme.onPrimary,
-                                  )
-                                : null,
-                            onPressed: transportEnabled
-                                ? _controller.togglePlayback
-                                : null,
-                            child: AnimatedSwitcher(
-                              duration: const Duration(milliseconds: 180),
-                              child: isBuffering
-                                  ? const _LoadingDots(
-                                      key: ValueKey('buffering'),
-                                    )
-                                  : Icon(
-                                      _controller.isPlaying
-                                          ? Icons.pause
-                                          : Icons.play_arrow,
-                                      key: ValueKey(_controller.isPlaying),
-                                    ),
-                            ),
-                          ),
-                        ),
-                        const SizedBox(width: 8),
-                        IconButton.filledTonal(
-                          onPressed: transportEnabled
-                              ? () => _controller.jumpBySeconds(30)
-                              : null,
-                          icon: const Icon(Icons.forward_30),
-                        ),
-                      ],
-                    ),
-                  ],
                 ),
               ),
             ),
@@ -621,49 +616,32 @@ class _ReadAloudScreenState extends State<ReadAloudScreen> {
       ),
       child: Padding(
         padding: const EdgeInsets.all(24),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+        child: Stack(
           children: [
-            Text(
-              _controller.document.title,
-              style: Theme.of(context).textTheme.headlineSmall,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Rich document surface with room for images, video, audio, and future semantic overlays. You can also drop supported files here.',
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
-            const SizedBox(height: 16),
-            Expanded(
-              child: Stack(
-                children: [
-                  Positioned.fill(
-                    child: DocumentSurface(
-                      document: _controller.document,
-                      fontFamily: _controller.fontFamily,
-                      fontScale: _controller.fontScale,
-                      spokenSelection: _controller.spokenSelection,
-                      focusedDisplayBlockId:
-                          _controller.readingFocusState.activeDisplayBlockId,
-                      autoFollowActive:
-                          _controller.readingFocusState.shouldAutoFollow,
-                      followRequestTick:
-                          _controller.readingFocusState.recenterRequestTick,
-                      onManualScrollWhileFollowing:
-                          _controller.suspendReaderFollow,
-                    ),
-                  ),
-                  if (_controller.readingFocusState.canRecenter)
-                    Positioned(
-                      right: 12,
-                      bottom: 12,
-                      child: ReadingFocusRecenterButton(
-                        onPressed: _controller.resumeReaderFollow,
-                      ),
-                    ),
-                ],
+            Positioned.fill(
+              child: DocumentSurface(
+                document: _controller.document,
+                fontFamily: _controller.fontFamily,
+                fontScale: _controller.fontScale,
+                spokenSelection: _controller.spokenSelection,
+                focusedDisplayBlockId:
+                    _controller.readingFocusState.activeDisplayBlockId,
+                autoFollowActive:
+                    _controller.readingFocusState.shouldAutoFollow,
+                followRequestTick:
+                    _controller.readingFocusState.recenterRequestTick,
+                onManualScrollWhileFollowing:
+                    _controller.suspendReaderFollow,
               ),
             ),
+            if (_controller.readingFocusState.canRecenter)
+              Positioned(
+                right: 12,
+                bottom: 12,
+                child: ReadingFocusRecenterButton(
+                  onPressed: _controller.resumeReaderFollow,
+                ),
+              ),
           ],
         ),
       ),

--- a/project/planning/progression.md
+++ b/project/planning/progression.md
@@ -1,6 +1,6 @@
 # Progression
 
-Last updated: April 3, 2026
+Last updated: April 4, 2026
 Status: Active progression
 
 ## Purpose
@@ -8,6 +8,10 @@ Status: Active progression
 This document is the execution sequence for implementation of the current final leaf specifications.
 
 It includes only leaf specifications that are marked final.
+
+Checked support leaves do not, by themselves, mean a user-facing feature is surfaced in the running app.
+
+For user-facing branches, the unchecked surfaced leaves remain the feature-completion gates.
 
 ## Ordering Rule
 
@@ -94,6 +98,8 @@ It includes only leaf specifications that are marked final.
 - [x] [Automatic Voice Casting and Override Resolution](../specifications/automatic-voice-casting-and-override-resolution.md)
 - [x] [Cast-Aware Speech Range Routing](../specifications/cast-aware-speech-range-routing.md)
 - [x] [Voice-Routed Progress and Diagnostics](../specifications/voice-routed-progress-and-diagnostics.md)
+- [ ] [Cast Voice Override Workflow](../specifications/cast-voice-override-workflow.md)
+- [ ] [Running-App Multi-Voice Playback Switching](../specifications/running-app-multi-voice-playback-switching.md)
 
 ### Speech Runtime Boundary
 
@@ -126,14 +132,21 @@ It includes only leaf specifications that are marked final.
 
 ### Reader Surface and Voice Management UI
 
+- [ ] [Primary Reader Control Set](../specifications/primary-reader-control-set.md)
+- [x] [Document Identity Outside Reading Surface](../specifications/document-identity-outside-reading-surface.md)
+- [ ] [Integrated Secondary Voice Access](../specifications/integrated-secondary-voice-access.md)
 - [x] [Voice Library Row and Information Affordance](../specifications/voice-library-row-and-information-affordance.md)
 - [x] [Cast Management Dialog Structure](../specifications/cast-management-dialog-structure.md)
+- [ ] [Appearance Mode Selection And System Following](../specifications/appearance-mode-selection-and-system-following.md)
 - [x] [Spoken Highlight Visual Presentation](../specifications/spoken-highlight-visual-presentation.md)
 - [x] [Follow-Along User Scroll Interaction](../specifications/follow-along-user-scroll-interaction.md)
 
 ### Reader Session and Live Input
 
-- [x] [Reader Session Continuity and Live Input](../specifications/reader-session-continuity-and-live-input.md)
+- [x] [File-Backed Document Restore And Directory Continuity](../specifications/file-backed-document-restore-and-directory-continuity.md)
+- [ ] [Remembered Reading Position And Startup Resume](../specifications/remembered-reading-position-and-startup-resume.md)
+- [x] [Watched-File Session Refresh](../specifications/watched-file-session-refresh.md)
+- [ ] [Live Input Menu Placement And Playing-State Continuation](../specifications/live-input-menu-placement-and-playing-state-continuation.md)
 
 ## Obligate Specifications
 

--- a/test/reader_controller_playback_test.dart
+++ b/test/reader_controller_playback_test.dart
@@ -191,6 +191,7 @@ void main() {
 
       expect(restored, isTrue);
       expect(controller.document.title, 'remembered.txt');
+      expect(controller.windowTitle, 'Read Aloud - remembered.txt');
       expect(
         controller.document.speakableText,
         contains('Restored documents should open by default.'),
@@ -247,6 +248,7 @@ void main() {
       expect(controller.isLiveReadEnabled, isTrue);
       expect(controller.liveReadFilePath, file.path);
       expect(controller.document.title, 'live.txt');
+      expect(controller.windowTitle, 'Read Aloud - live.txt');
       expect(controller.document.speakableText, contains('Alpha beta.'));
 
       await file.writeAsString('Gamma delta.');
@@ -260,6 +262,20 @@ void main() {
 
       expect(controller.document.speakableText, contains('Gamma delta.'));
       expect(controller.statusMessage, contains('Live read updated'));
+    });
+
+    test('uses document title as the window title fallback for non-file content', () async {
+      final engine = _FakeTtsEngine();
+      final controller = ReaderController(ttsEngine: engine);
+      addTearDown(controller.dispose);
+
+      await controller.initialize();
+
+      expect(controller.windowTitle, 'Read Aloud - For Probe');
+
+      await controller.importPastedText('Alpha beta.');
+
+      expect(controller.windowTitle, 'Read Aloud - Pasted Text');
     });
 
     test('maintains reading focus state across progress, pause, and user yield', () async {

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -10,8 +10,17 @@ void main() {
 
     expect(find.text('Read Aloud'), findsWidgets);
     expect(find.text('Reader Controls'), findsOneWidget);
-    expect(find.text('For Probe'), findsWidgets);
-    expect(find.text('TTS Input Trace'), findsOneWidget);
+    expect(find.text('For Probe'), findsNothing);
+    expect(
+      tester.widgetList<Title>(find.byType(Title)).any(
+        (widget) => widget.title == 'Read Aloud - For Probe',
+      ),
+      isTrue,
+    );
+    expect(
+      find.textContaining('Rich document surface with room for images'),
+      findsNothing,
+    );
     expect(
       find.textContaining(
         'Short phrases for tracing how "for" is realized by the TTS pipeline.',
@@ -35,5 +44,6 @@ void main() {
     expect(tester.takeException(), isNull);
     expect(find.byIcon(Icons.play_arrow), findsOneWidget);
     expect(find.text('Play'), findsNothing);
+    expect(find.text('For Probe'), findsNothing);
   });
 }


### PR DESCRIPTION
## What Changed
- Lands the next completed feature slice from the current 0.3.0 stack.

## Why
- Keeps the accepted feature work moving to `main` while the newer design-review docs remain separate.

## Validation
- No additional checks were run in this publish step.
- Validation was performed earlier during the implementation round for this slice.
