### PR TITLE
Finalize audio-authoritative playback coordination

### DIFF
--- a/lib/src/controllers/reader_controller.dart
+++ b/lib/src/controllers/reader_controller.dart
@@ -43,6 +43,20 @@ import '../services/tts_engine.dart';
 import '../services/voice_session_realization_service.dart';
 
 class ReaderController extends ChangeNotifier {
+  static const Duration _healthyFollowerUpdateInterval = Duration(
+    milliseconds: 100,
+  );
+  static const Duration _lowWaterFollowerUpdateInterval = Duration(
+    milliseconds: 180,
+  );
+  static const Duration _criticalFollowerUpdateInterval = Duration(
+    milliseconds: 250,
+  );
+  static const int _healthyFollowerSoftWordDelta = 2;
+  static const int _lowWaterFollowerSoftWordDelta = 3;
+  static const int _criticalFollowerSoftWordDelta = 4;
+  static const int _followerHardResyncWordDelta = 10;
+
   ReaderController({
     DocumentImportService? importer,
     DocumentAccessService? documentAccessService,
@@ -103,6 +117,7 @@ class ReaderController extends ChangeNotifier {
   StreamSubscription<FileSystemEvent>? _liveReadSubscription;
   Timer? _liveReadReloadDebounce;
   Timer? _resumePersistenceDebounce;
+  Timer? _followerProgressDebounce;
 
   bool _isInitializing = true;
   bool _isImporting = false;
@@ -133,6 +148,8 @@ class ReaderController extends ChangeNotifier {
   SpokenSelection _spokenSelection = const SpokenSelection.none();
   ReadingFocusState _readingFocusState = const ReadingFocusState();
   String? _activePlaybackDocumentId;
+  TtsProgressUpdate? _pendingFollowerProgressUpdate;
+  DateTime? _lastFollowerProgressAppliedAt;
 
   int _currentWordIndex = 0;
   double _wordsPerSecond = 2.8;
@@ -294,6 +311,7 @@ class ReaderController extends ChangeNotifier {
       if (_activePlaybackDocumentId == null) {
         return;
       }
+      _flushPendingFollowerProgress();
       unawaited(_flushResumePersistence());
       _finalizeActiveSpokenChunk();
       _activePlaybackDocumentId = null;
@@ -325,6 +343,7 @@ class ReaderController extends ChangeNotifier {
       if (_activePlaybackDocumentId == null) {
         return;
       }
+      _flushPendingFollowerProgress();
       unawaited(_flushResumePersistence());
       _statusMessage = message;
       _activePlaybackDocumentId = null;
@@ -842,6 +861,7 @@ class ReaderController extends ChangeNotifier {
     }
 
     _statusMessage = null;
+    _resetFollowerProgressSynchronization();
     _narrationState = _narrationState.copyWith(
       currentSectionMode: _sectionModeForCurrentPosition(),
       discourseMode: _discourseModeForCurrentPosition(),
@@ -881,6 +901,7 @@ class ReaderController extends ChangeNotifier {
   }
 
   Future<void> pausePlayback() async {
+    _flushPendingFollowerProgress();
     await _ttsEngine.pause();
     await _flushResumePersistence();
     _finalizeActiveSpokenChunk();
@@ -902,6 +923,7 @@ class ReaderController extends ChangeNotifier {
     _currentWordIndex = snappedTarget;
     _playbackEndedAtDocumentEnd = false;
     _activeSpokenChunkId = null;
+    _resetFollowerProgressSynchronization();
     _spokenSelection = const SpokenSelection.none();
     _readingFocusState = const ReadingFocusState();
     _narrationState = _narrationState
@@ -1444,6 +1466,7 @@ class ReaderController extends ChangeNotifier {
     _playbackActivity = const TtsPlaybackActivity.idle();
     _spokenChunkRecords.clear();
     _activeSpokenChunkId = null;
+    _resetFollowerProgressSynchronization();
     _spokenSelection = const SpokenSelection.none();
     _castVoiceOverrides.clear();
     _readingFocusState = const ReadingFocusState();
@@ -1552,26 +1575,13 @@ class ReaderController extends ChangeNotifier {
       0,
       math.max(_document.wordCount - 1, 0),
     );
-    _spokenSelection = _spokenSelectionMapperService.map(
-      SpokenSelectionMapperInput(
-        displayDocument: _document.displayDocument,
-        speechDocument: _document.speechDocument,
-        positionMap: _document.positionMap,
-        progress: update,
-      ),
-    );
-    _readingFocusState = _readingFocusState.copyWith(
-      playbackActive: true,
-      activeDisplayBlockId: _spokenSelection.displayBlockId,
-      clearActiveDisplayBlockId: _spokenSelection.displayBlockId == null,
-    );
     _playbackEndedAtDocumentEnd = false;
     _narrationState = _narrationState.copyWith(
       currentSectionMode: _sectionModeForCurrentPosition(),
       discourseMode: _discourseModeForCurrentPosition(),
     );
     _scheduleResumePersistence();
-    notifyListeners();
+    _queueFollowerProgressUpdate(update);
   }
 
   @override
@@ -1582,6 +1592,7 @@ class ReaderController extends ChangeNotifier {
     _liveReadReloadDebounce?.cancel();
     _liveReadSubscription?.cancel();
     _resumePersistenceDebounce?.cancel();
+    _followerProgressDebounce?.cancel();
     _ttsEngine.onStart = null;
     _ttsEngine.onStatus = null;
     _ttsEngine.onProgress = null;
@@ -2511,6 +2522,174 @@ class ReaderController extends ChangeNotifier {
     _wordsPerSecond = _estimateWordsPerSecond(voiceId: voiceId, rate: rate);
   }
 
+  void _queueFollowerProgressUpdate(TtsProgressUpdate update) {
+    _pendingFollowerProgressUpdate = update;
+    final policy = _currentFollowerSyncPolicy();
+
+    if (_shouldFlushFollowerProgressImmediately(update, policy)) {
+      _flushPendingFollowerProgress();
+      return;
+    }
+
+    final lastAppliedAt = _lastFollowerProgressAppliedAt;
+    if (lastAppliedAt == null) {
+      _flushPendingFollowerProgress();
+      return;
+    }
+
+    final elapsedSinceLastApply = DateTime.now().difference(lastAppliedAt);
+    final remainingDelay = policy.flushInterval - elapsedSinceLastApply;
+    if (!remainingDelay.isNegative && remainingDelay > Duration.zero) {
+      _followerProgressDebounce?.cancel();
+      _followerProgressDebounce = Timer(
+        remainingDelay,
+        _flushPendingFollowerProgress,
+      );
+      return;
+    }
+
+    _flushPendingFollowerProgress();
+  }
+
+  bool _shouldFlushFollowerProgressImmediately(
+    TtsProgressUpdate update,
+    _FollowerSyncPolicy policy,
+  ) {
+    if (!_spokenSelection.hasSelection) {
+      return true;
+    }
+
+    final pendingWordEndIndex = _resolvedProgressWordEndIndex(update);
+    final visibleWordEndIndex = _spokenSelection.speechEndWordIndex ?? 0;
+    final wordDrift = pendingWordEndIndex - visibleWordEndIndex;
+
+    if (wordDrift >= _followerHardResyncWordDelta) {
+      return true;
+    }
+
+    if (update.segmentId != null && update.segmentId != _spokenSelection.segmentId) {
+      return true;
+    }
+
+    if (update.routeId != _spokenSelection.routeId ||
+        update.castId != _spokenSelection.castId ||
+        update.dialogueSpanId != _spokenSelection.dialogueSpanId) {
+      return true;
+    }
+
+    final lastAppliedAt = _lastFollowerProgressAppliedAt;
+    if (lastAppliedAt == null) {
+      return true;
+    }
+
+    final elapsedSinceLastApply = DateTime.now().difference(lastAppliedAt);
+    return wordDrift >= policy.softWordDelta &&
+        elapsedSinceLastApply >= policy.flushInterval;
+  }
+
+  void _flushPendingFollowerProgress() {
+    _followerProgressDebounce?.cancel();
+    _followerProgressDebounce = null;
+
+    final update = _pendingFollowerProgressUpdate;
+    if (update == null) {
+      return;
+    }
+    _pendingFollowerProgressUpdate = null;
+    _applyFollowerProgressUpdate(update);
+  }
+
+  void _applyFollowerProgressUpdate(TtsProgressUpdate update) {
+    final nextSelection = _spokenSelectionMapperService.map(
+      SpokenSelectionMapperInput(
+        displayDocument: _document.displayDocument,
+        speechDocument: _document.speechDocument,
+        positionMap: _document.positionMap,
+        progress: update,
+      ),
+    );
+    final nextReadingFocusState = _readingFocusState.copyWith(
+      playbackActive: true,
+      activeDisplayBlockId: nextSelection.displayBlockId,
+      clearActiveDisplayBlockId: nextSelection.displayBlockId == null,
+    );
+
+    final selectionChanged = !_sameSpokenSelection(
+      _spokenSelection,
+      nextSelection,
+    );
+    final readingFocusChanged = !_sameReadingFocusState(
+      _readingFocusState,
+      nextReadingFocusState,
+    );
+
+    _spokenSelection = nextSelection;
+    _readingFocusState = nextReadingFocusState;
+    _lastFollowerProgressAppliedAt = DateTime.now();
+
+    if (selectionChanged || readingFocusChanged) {
+      notifyListeners();
+    }
+  }
+
+  void _resetFollowerProgressSynchronization() {
+    _pendingFollowerProgressUpdate = null;
+    _lastFollowerProgressAppliedAt = null;
+    _followerProgressDebounce?.cancel();
+    _followerProgressDebounce = null;
+  }
+
+  _FollowerSyncPolicy _currentFollowerSyncPolicy() {
+    switch (_playbackActivity.bufferPressure) {
+      case TtsBufferPressure.critical:
+        return const _FollowerSyncPolicy(
+          flushInterval: _criticalFollowerUpdateInterval,
+          softWordDelta: _criticalFollowerSoftWordDelta,
+        );
+      case TtsBufferPressure.lowWater:
+        return const _FollowerSyncPolicy(
+          flushInterval: _lowWaterFollowerUpdateInterval,
+          softWordDelta: _lowWaterFollowerSoftWordDelta,
+        );
+      case TtsBufferPressure.none:
+      case TtsBufferPressure.healthy:
+        return const _FollowerSyncPolicy(
+          flushInterval: _healthyFollowerUpdateInterval,
+          softWordDelta: _healthyFollowerSoftWordDelta,
+        );
+    }
+  }
+
+  int _resolvedProgressWordEndIndex(TtsProgressUpdate update) {
+    return update.wordEndIndex ??
+        _document.wordIndexForOffset(_utteranceStartOffset + update.endOffset);
+  }
+
+  bool _sameSpokenSelection(SpokenSelection left, SpokenSelection right) {
+    return left.precision == right.precision &&
+        left.confidence == right.confidence &&
+        left.segmentId == right.segmentId &&
+        left.displayBlockId == right.displayBlockId &&
+        left.displayStart == right.displayStart &&
+        left.displayEnd == right.displayEnd &&
+        left.speechStartWordIndex == right.speechStartWordIndex &&
+        left.speechEndWordIndex == right.speechEndWordIndex &&
+        left.voiceId == right.voiceId &&
+        left.routeId == right.routeId &&
+        left.castId == right.castId &&
+        left.dialogueSpanId == right.dialogueSpanId;
+  }
+
+  bool _sameReadingFocusState(
+    ReadingFocusState left,
+    ReadingFocusState right,
+  ) {
+    return left.playbackActive == right.playbackActive &&
+        left.followMode == right.followMode &&
+        left.activeDisplayBlockId == right.activeDisplayBlockId &&
+        left.recenterRequestTick == right.recenterRequestTick;
+  }
+
   void _finalizeActiveSpokenChunk() {
     final chunkId = _activeSpokenChunkId;
     if (chunkId == null) {
@@ -2645,4 +2824,14 @@ bool _looksLikePermissionIssue(Object error) {
       text.contains('access denied') ||
       text.contains('sandbox') ||
       text.contains('security-scoped');
+}
+
+class _FollowerSyncPolicy {
+  const _FollowerSyncPolicy({
+    required this.flushInterval,
+    required this.softWordDelta,
+  });
+
+  final Duration flushInterval;
+  final int softWordDelta;
 }

--- a/lib/src/services/kokoro_playback_coordination.dart
+++ b/lib/src/services/kokoro_playback_coordination.dart
@@ -1,3 +1,5 @@
+import 'tts_engine.dart';
+
 class KokoroPlaybackQueueSnapshot {
   const KokoroPlaybackQueueSnapshot({
     required this.activeChunkCount,
@@ -14,6 +16,71 @@ class KokoroPlaybackQueueSnapshot {
   final int pendingChunkCount;
   final int remainingPlannedChunkCount;
   final int? playerRelativeIndex;
+}
+
+enum KokoroForwardRecoveryAction {
+  none,
+  waitForPreparedAudio,
+  resumeFromNextBufferedChunk,
+}
+
+class KokoroForwardRecoveryPlan {
+  const KokoroForwardRecoveryPlan._({
+    required this.action,
+    this.nextChunkIndex,
+  });
+
+  const KokoroForwardRecoveryPlan.none()
+    : this._(action: KokoroForwardRecoveryAction.none);
+
+  const KokoroForwardRecoveryPlan.waitForPreparedAudio()
+    : this._(action: KokoroForwardRecoveryAction.waitForPreparedAudio);
+
+  const KokoroForwardRecoveryPlan.resumeFromNextBufferedChunk(
+    int nextChunkIndex,
+  ) : this._(
+         action: KokoroForwardRecoveryAction.resumeFromNextBufferedChunk,
+         nextChunkIndex: nextChunkIndex,
+       );
+
+  final KokoroForwardRecoveryAction action;
+  final int? nextChunkIndex;
+}
+
+const Duration kokoroTargetBufferedLeadTime = Duration(seconds: 8);
+const Duration kokoroLowWaterBufferedLeadTime = Duration(seconds: 4);
+const Duration kokoroCriticalBufferedLeadTime = Duration(seconds: 2);
+const Duration kokoroStartupMinimumBufferedLeadTime = Duration(seconds: 4);
+const int kokoroStartupMinimumBufferedChunkCount = 2;
+const int kokoroStartupPreparedChunkWindow = 3;
+
+TtsBufferPressure kokoroBufferPressureForLeadTime(Duration leadTime) {
+  if (leadTime <= kokoroCriticalBufferedLeadTime) {
+    return TtsBufferPressure.critical;
+  }
+  if (leadTime <= kokoroLowWaterBufferedLeadTime) {
+    return TtsBufferPressure.lowWater;
+  }
+  return TtsBufferPressure.healthy;
+}
+
+bool kokoroIsStartupWarmEnough({
+  required int bufferedChunkCount,
+  required Duration bufferedLeadTime,
+  required int pendingChunkCount,
+  required int remainingPlannedChunkCount,
+}) {
+  final hasFutureWork = pendingChunkCount > 0 || remainingPlannedChunkCount > 0;
+  if (!hasFutureWork) {
+    return true;
+  }
+
+  if (bufferedLeadTime >= kokoroTargetBufferedLeadTime) {
+    return true;
+  }
+
+  return bufferedChunkCount >= kokoroStartupMinimumBufferedChunkCount &&
+      bufferedLeadTime >= kokoroStartupMinimumBufferedLeadTime;
 }
 
 class KokoroRecoveryWordBoundary {
@@ -44,6 +111,21 @@ bool kokoroShouldEnterUnderrunRecovery(KokoroPlaybackQueueSnapshot snapshot) {
   return kokoroHasBufferedFutureChunks(snapshot) ||
       snapshot.pendingChunkCount > 0 ||
       snapshot.remainingPlannedChunkCount > 0;
+}
+
+KokoroForwardRecoveryPlan kokoroPlanForwardRecovery(
+  KokoroPlaybackQueueSnapshot snapshot,
+) {
+  final nextChunkIndex = kokoroNextRecoveryStartIndex(snapshot);
+  if (nextChunkIndex != null) {
+    return KokoroForwardRecoveryPlan.resumeFromNextBufferedChunk(
+      nextChunkIndex,
+    );
+  }
+  if (snapshot.pendingChunkCount > 0 || snapshot.remainingPlannedChunkCount > 0) {
+    return const KokoroForwardRecoveryPlan.waitForPreparedAudio();
+  }
+  return const KokoroForwardRecoveryPlan.none();
 }
 
 bool kokoroHasBufferedFutureChunks(KokoroPlaybackQueueSnapshot snapshot) {
@@ -135,6 +217,91 @@ List<KokoroRecoveryWordSlice> kokoroPlanRecoverableChunkSlices({
     return const <KokoroRecoveryWordSlice>[];
   }
   return List<KokoroRecoveryWordSlice>.unmodifiable(slices);
+}
+
+List<T> kokoroBuildInitialPlaybackQueue<T>({
+  required T firstChunk,
+  required Iterable<T> stagedChunks,
+  required String Function(T chunk) chunkIdOf,
+  required int Function(T chunk) startWordIndexOf,
+  required int Function(T chunk) startOffsetOf,
+}) {
+  final chunksById = <String, T>{chunkIdOf(firstChunk): firstChunk};
+  for (final chunk in stagedChunks) {
+    chunksById[chunkIdOf(chunk)] = chunk;
+  }
+
+  final ordered = chunksById.values.toList(growable: false)
+    ..sort((left, right) {
+      final wordComparison =
+          startWordIndexOf(left).compareTo(startWordIndexOf(right));
+      if (wordComparison != 0) {
+        return wordComparison;
+      }
+      final offsetComparison =
+          startOffsetOf(left).compareTo(startOffsetOf(right));
+      if (offsetComparison != 0) {
+        return offsetComparison;
+      }
+      return chunkIdOf(left).compareTo(chunkIdOf(right));
+  });
+  return ordered;
+}
+
+int kokoroPlaybackInsertIndex<T>({
+  required List<T> activeChunks,
+  required T incomingChunk,
+  required String Function(T chunk) chunkIdOf,
+  required int Function(T chunk) startWordIndexOf,
+  required int Function(T chunk) startOffsetOf,
+}) {
+  for (var index = 0; index < activeChunks.length; index += 1) {
+    final comparison = _comparePlaybackChunkOrder(
+      activeChunks[index],
+      incomingChunk,
+      chunkIdOf: chunkIdOf,
+      startWordIndexOf: startWordIndexOf,
+      startOffsetOf: startOffsetOf,
+    );
+    if (comparison >= 0) {
+      return index;
+    }
+  }
+  return activeChunks.length;
+}
+
+int? kokoroFirstFutureReplacementIndex<T>({
+  required List<T> activeChunks,
+  required int currentChunkIndex,
+  required int replacementStartWordIndex,
+  required int Function(T chunk) startWordIndexOf,
+}) {
+  final startIndex = currentChunkIndex + 1;
+  for (var index = startIndex; index < activeChunks.length; index += 1) {
+    if (startWordIndexOf(activeChunks[index]) >= replacementStartWordIndex) {
+      return index;
+    }
+  }
+  return null;
+}
+
+int _comparePlaybackChunkOrder<T>(
+  T left,
+  T right, {
+  required String Function(T chunk) chunkIdOf,
+  required int Function(T chunk) startWordIndexOf,
+  required int Function(T chunk) startOffsetOf,
+}) {
+  final wordComparison =
+      startWordIndexOf(left).compareTo(startWordIndexOf(right));
+  if (wordComparison != 0) {
+    return wordComparison;
+  }
+  final offsetComparison = startOffsetOf(left).compareTo(startOffsetOf(right));
+  if (offsetComparison != 0) {
+    return offsetComparison;
+  }
+  return chunkIdOf(left).compareTo(chunkIdOf(right));
 }
 
 int? _findRecoveryBoundary({

--- a/lib/src/services/kokoro_tts_engine.dart
+++ b/lib/src/services/kokoro_tts_engine.dart
@@ -38,6 +38,10 @@ class KokoroTtsEngine
   static const String _fallbackNormalizationVersion =
       'read-aloud-normalization-v1';
   static const int _targetChunkWordCount = 18;
+  static const Duration _startupWarmupPollInterval = Duration(
+    milliseconds: 40,
+  );
+  static const Duration _startupWarmupMaxWait = Duration(seconds: 5);
 
   final AudioPlayer _player;
   final PlaybackInstrumentationService _instrumentation =
@@ -89,6 +93,8 @@ class KokoroTtsEngine
   int _remainingPlannedChunkCount = 0;
   bool _waitingForUnderrunRecovery = false;
   Future<void> _audioQueueMutation = Future<void>.value();
+  TtsBufferPressure _lastRecordedBufferPressure = TtsBufferPressure.none;
+  final List<_PlaybackChunk> _stagedReadyChunks = <_PlaybackChunk>[];
 
   @override
   set onStart(void Function()? callback) => _onStart = callback;
@@ -160,8 +166,8 @@ class KokoroTtsEngine
             },
           );
           _emitActivity(
-            TtsPlaybackActivity(
-              phase: TtsPlaybackPhase.buffering,
+            _playbackActivityForPhase(
+              TtsPlaybackPhase.buffering,
               bufferedChunkCount: _activeChunks.length,
               totalChunkCount: _expectedChunkCount,
             ),
@@ -535,17 +541,18 @@ class KokoroTtsEngine
       );
       final hasPlannedChunks =
           request.chunkPlan != null && request.chunkPlan!.chunks.isNotEmpty;
+      final preparedStartupWindow = hasPlannedChunks
+          ? await _preparePlannedChunkWindow(
+              request: request,
+              specs: request.chunkPlan!.chunks
+                  .take(kokoroStartupPreparedChunkWindow)
+                  .toList(growable: false),
+              initialSearchOffset: 0,
+              languageTag: languageTag,
+            )
+          : null;
       final chunks = hasPlannedChunks
-          ? <_QueuedChunk>[
-              (
-                await _preparePlannedChunk(
-                  request: request,
-                  spec: request.chunkPlan!.chunks.first,
-                  searchOffset: 0,
-                  languageTag: languageTag,
-                )
-              ).chunk,
-            ]
+          ? preparedStartupWindow!.chunks
           : await _prepareChunks(request, languageTag: languageTag);
       if (chunks.isEmpty) {
         _onError?.call('Kokoro could not prepare readable text for synthesis.');
@@ -566,13 +573,13 @@ class KokoroTtsEngine
           ? request.chunkPlan!.chunks.length
           : chunks.length;
       _remainingPlannedChunkCount = hasPlannedChunks
-          ? request.chunkPlan!.chunks.length - 1
+          ? request.chunkPlan!.chunks.length - chunks.length
           : 0;
       _audioQueueMutation = Future<void>.value();
 
       _emitActivity(
-        TtsPlaybackActivity(
-          phase: TtsPlaybackPhase.buffering,
+        _playbackActivityForPhase(
+          TtsPlaybackPhase.buffering,
           totalChunkCount: _expectedChunkCount,
         ),
       );
@@ -607,18 +614,22 @@ class KokoroTtsEngine
       );
 
       if (hasPlannedChunks && request.chunkPlan!.chunks.length > 1) {
+        final remainingSpecs = request.chunkPlan!.chunks
+            .skip(chunks.length)
+            .toList(growable: false);
         unawaited(
           _queueRemainingPlannedChunks(
             requestToken: requestToken,
             request: request,
             generationId: generationId,
             languageTag: languageTag,
-            specs: request.chunkPlan!.chunks.skip(1).toList(growable: false),
-            initialSearchOffset:
-                chunks.first.startOffset + chunks.first.text.length,
+            specs: remainingSpecs,
+            initialSearchOffset: preparedStartupWindow!.nextSearchOffset,
           ),
         );
-      } else if (chunks.length > 1) {
+      }
+
+      if (chunks.length > 1) {
         await speechRuntime.prepareChunkPlan(
           sessionId: _activeSessionId!,
           generationId: generationId,
@@ -639,25 +650,59 @@ class KokoroTtsEngine
       }
 
       final firstChunk = await _firstChunkCompleter!.future;
-      if (requestToken != _requestToken ||
-          generationId != _activeGenerationId) {
+      if (requestToken != _requestToken || _activeGenerationId == null) {
         return;
       }
 
-      _activeChunks = <_PlaybackChunk>[firstChunk];
+      final startupWarmupStartedAt = DateTime.now();
+      await _awaitStartupWarmup(firstChunk: firstChunk);
+      if (requestToken != _requestToken || _activeGenerationId == null) {
+        return;
+      }
+      final activeGenerationId = _activeGenerationId!;
+
+      final initialBufferedChunks = kokoroBuildInitialPlaybackQueue(
+        firstChunk: firstChunk,
+        stagedChunks: _drainStagedReadyChunks(),
+        chunkIdOf: (chunk) => chunk.chunkId,
+        startWordIndexOf: (chunk) => chunk.startWordIndex,
+        startOffsetOf: (chunk) => chunk.startOffset,
+      );
+      _recordMetric(
+        'startupWarmup',
+        chunkId: firstChunk.chunkId,
+        voiceId: firstChunk.voiceId,
+        value: <String, Object?>{
+          'waitMillis': DateTime.now()
+              .difference(startupWarmupStartedAt)
+              .inMilliseconds,
+          'bufferedChunkCount': initialBufferedChunks.length,
+          'bufferedLeadTimeMs': _initialBufferedQueueLeadTime(
+            initialBufferedChunks,
+          ).inMilliseconds,
+          'pendingChunkCount': _pendingChunksById.length,
+          'remainingPlannedChunkCount': _remainingPlannedChunkCount,
+        },
+      );
+      _activeChunks = initialBufferedChunks;
       _currentChunkIndex = 0;
       _currentQueueBaseIndex = 0;
-      _activePlaybackToken = requestToken;
       _waitingForUnderrunRecovery = false;
       await _player.setVolume(_volume);
-      await _player.setAudioSources(<AudioSource>[
-        AudioSource.file(firstChunk.filePath),
-      ]);
+      await _player.setAudioSources(
+        initialBufferedChunks
+            .map((chunk) => AudioSource.file(chunk.filePath))
+            .toList(growable: false),
+      );
+      _activePlaybackToken = requestToken;
+      await _flushStagedReadyChunksToActiveQueue(
+        generationId: activeGenerationId,
+      );
       _emitProgressForChunkWord(0, 0, elapsedInChunk: Duration.zero);
       _emitActivity(
-        TtsPlaybackActivity(
-          phase: TtsPlaybackPhase.playing,
-          bufferedChunkCount: 1,
+        _playbackActivityForPhase(
+          TtsPlaybackPhase.playing,
+          bufferedChunkCount: _activeChunks.length,
           totalChunkCount: _expectedChunkCount,
         ),
       );
@@ -901,8 +946,8 @@ class KokoroTtsEngine
     final totalChunkCount = _expectedChunkCount;
     if (_activePlaybackToken == null) {
       _emitActivity(
-        TtsPlaybackActivity(
-          phase: TtsPlaybackPhase.buffering,
+        _playbackActivityForPhase(
+          TtsPlaybackPhase.buffering,
           totalChunkCount: totalChunkCount,
         ),
       );
@@ -910,8 +955,8 @@ class KokoroTtsEngine
     }
 
     _emitActivity(
-      TtsPlaybackActivity(
-        phase: TtsPlaybackPhase.playing,
+      _playbackActivityForPhase(
+        TtsPlaybackPhase.playing,
         bufferedChunkCount: _activeChunks.length,
         totalChunkCount: totalChunkCount,
       ),
@@ -1012,39 +1057,19 @@ class KokoroTtsEngine
     }
 
     if (_activePlaybackToken == null) {
+      _stageReadyChunk(playbackChunk);
       return;
     }
 
-    _audioQueueMutation = _audioQueueMutation.then((_) async {
-      if (_activePlaybackToken == null ||
-          event.generationId != _activeGenerationId) {
-        return;
-      }
-
-      _activeChunks = List<_PlaybackChunk>.from(_activeChunks)
-        ..add(playbackChunk);
-      final waitingForRecovery = _waitingForUnderrunRecovery;
-      if (!waitingForRecovery) {
-        await _player.addAudioSource(AudioSource.file(playbackChunk.filePath));
-      }
-      _recordMetric(
-        'prefetchLeadTimeMs',
-        chunkId: playbackChunk.chunkId,
-        voiceId: playbackChunk.voiceId,
-        value: _bufferedLeadTime().inMilliseconds,
-      );
-      _emitActivity(
-        TtsPlaybackActivity(
-          phase: TtsPlaybackPhase.playing,
-          bufferedChunkCount: _activeChunks.length,
-          totalChunkCount: _expectedChunkCount,
-        ),
-      );
-    });
-    await _audioQueueMutation;
+    await _appendReadyChunkToActiveQueue(
+      playbackChunk,
+      generationId: event.generationId,
+    );
+    final recoveryPlan = kokoroPlanForwardRecovery(_playbackQueueSnapshot());
     if (_activePlaybackToken != null &&
         _player.playerState.processingState == ProcessingState.completed &&
-        kokoroHasBufferedFutureChunks(_playbackQueueSnapshot())) {
+        recoveryPlan.action ==
+            KokoroForwardRecoveryAction.resumeFromNextBufferedChunk) {
       _waitingForUnderrunRecovery = true;
     }
     await _resumeAfterUnderrunIfPossible();
@@ -1061,26 +1086,40 @@ class KokoroTtsEngine
       return;
     }
     final failedChunk = _pendingChunksById.remove(chunkId);
-    if (chunkId == _firstPendingChunkId) {
+    final failedWasPriorityChunk = chunkId == _firstPendingChunkId;
+    final generationId = event.generationId;
+    if (failedChunk != null && generationId != null) {
+      _recordMetric(
+        'recoverableChunkFailureDetected',
+        chunkId: failedChunk.chunkId,
+        voiceId: failedChunk.voiceId,
+        value: <String, Object?>{
+          'failedWasPriorityChunk': failedWasPriorityChunk,
+          'duringStartupWarmup': _activePlaybackToken == null,
+          'message': event.message,
+          'routeId': failedChunk.routeId,
+          'castId': failedChunk.castId,
+          'dialogueSpanId': failedChunk.dialogueSpanId,
+        },
+      );
+      unawaited(
+        _attemptRecoverableChunkFailure(
+          failedChunk: failedChunk,
+          generationId: generationId,
+          failedWasPriorityChunk: failedWasPriorityChunk,
+          failureMessage: event.message,
+        ),
+      );
+      return;
+    }
+
+    if (failedWasPriorityChunk) {
       final completer = _firstChunkCompleter;
       if (completer != null && !completer.isCompleted) {
         completer.completeError(
           StateError(event.message ?? 'Kokoro failed to prepare audio.'),
         );
       }
-      return;
-    }
-
-    final generationId = event.generationId;
-    if (failedChunk != null &&
-        generationId != null &&
-        _activePlaybackToken != null) {
-      unawaited(
-        _attemptRecoverableChunkFailure(
-          failedChunk: failedChunk,
-          generationId: generationId,
-        ),
-      );
       return;
     }
 
@@ -1100,6 +1139,8 @@ class KokoroTtsEngine
   Future<void> _attemptRecoverableChunkFailure({
     required _QueuedChunk failedChunk,
     required String generationId,
+    required bool failedWasPriorityChunk,
+    required String? failureMessage,
   }) async {
     final speechRuntime = _speechRuntime;
     final sessionId = _activeSessionId;
@@ -1111,11 +1152,30 @@ class KokoroTtsEngine
 
     final recoveryChunks = await _buildRecoverableFailureChunks(failedChunk);
     if (recoveryChunks.isEmpty) {
-      _onError?.call(
-        'Kokoro could not prepare a later chunk: recoverable fallback was unavailable for "${failedChunk.text}".',
-      );
+      if (failedWasPriorityChunk) {
+        final completer = _firstChunkCompleter;
+        if (completer != null && !completer.isCompleted) {
+          completer.completeError(
+            StateError(
+              failureMessage ??
+                  'Kokoro failed to prepare startup audio for this passage.',
+            ),
+          );
+        }
+      } else {
+        _onError?.call(
+          'Kokoro could not prepare a later chunk: recoverable fallback was unavailable for "${failedChunk.text}".',
+        );
+      }
       return;
     }
+
+    _stagedReadyChunks.removeWhere(
+      (chunk) => chunk.startWordIndex >= failedChunk.startWordIndex,
+    );
+    await _discardFutureBufferedChunksFromStartWordIndex(
+      failedChunk.startWordIndex,
+    );
 
     final remainingPending = _pendingChunksById.values
         .where((chunk) => chunk.generationOrder > failedChunk.generationOrder)
@@ -1146,6 +1206,9 @@ class KokoroTtsEngine
     final newGenerationId =
         '${generationId}_recovery_${DateTime.now().microsecondsSinceEpoch}';
     _activeGenerationId = newGenerationId;
+    if (failedWasPriorityChunk) {
+      _firstPendingChunkId = rebuiltWithFreshIds.first.chunkId;
+    }
     _pendingChunksById = <String, _QueuedChunk>{
       for (final chunk in rebuiltWithFreshIds) chunk.chunkId: chunk,
     };
@@ -1319,6 +1382,8 @@ class KokoroTtsEngine
     _expectedChunkCount = 0;
     _remainingPlannedChunkCount = 0;
     _waitingForUnderrunRecovery = false;
+    _lastRecordedBufferPressure = TtsBufferPressure.none;
+    _stagedReadyChunks.clear();
   }
 
   Future<List<_QueuedChunk>> _prepareChunks(
@@ -1407,7 +1472,11 @@ class KokoroTtsEngine
         fallbackRecoveryDepth: 0,
       );
       prepared.add(chunk);
-      searchOffset = startOffset + spec.speakText.length;
+      searchOffset = _nextChunkSearchOffset(
+        fullTextLength: request.text.length,
+        startOffset: startOffset,
+        chunkTextLength: spec.speakText.length,
+      );
     }
 
     return prepared;
@@ -1464,7 +1533,35 @@ class KokoroTtsEngine
         dialogueSpanId: spec.dialogueSpanId,
         fallbackRecoveryDepth: 0,
       ),
-      nextSearchOffset: startOffset + spec.speakText.length,
+      nextSearchOffset: _nextChunkSearchOffset(
+        fullTextLength: request.text.length,
+        startOffset: startOffset,
+        chunkTextLength: spec.speakText.length,
+      ),
+    );
+  }
+
+  Future<_PreparedPlannedChunkWindow> _preparePlannedChunkWindow({
+    required TtsSpeakRequest request,
+    required List<ChunkSpec> specs,
+    required int initialSearchOffset,
+    required String languageTag,
+  }) async {
+    final chunks = <_QueuedChunk>[];
+    var searchOffset = initialSearchOffset;
+    for (final spec in specs) {
+      final prepared = await _preparePlannedChunk(
+        request: request,
+        spec: spec,
+        searchOffset: searchOffset,
+        languageTag: languageTag,
+      );
+      chunks.add(prepared.chunk);
+      searchOffset = prepared.nextSearchOffset;
+    }
+    return _PreparedPlannedChunkWindow(
+      chunks: chunks,
+      nextSearchOffset: searchOffset,
     );
   }
 
@@ -1566,6 +1663,8 @@ class KokoroTtsEngine
     _expectedChunkCount = 0;
     _remainingPlannedChunkCount = 0;
     _waitingForUnderrunRecovery = false;
+    _lastRecordedBufferPressure = TtsBufferPressure.none;
+    _stagedReadyChunks.clear();
     _audioQueueMutation = Future<void>.value();
     await _player.stop();
     await _player.clearAudioSources();
@@ -1707,35 +1806,212 @@ class KokoroTtsEngine
       return;
     }
 
-    final nextChunkIndex = kokoroNextRecoveryStartIndex(
-      _playbackQueueSnapshot(),
-    );
-    if (nextChunkIndex == null) {
+    final recoveryPlan = kokoroPlanForwardRecovery(_playbackQueueSnapshot());
+    if (recoveryPlan.action !=
+        KokoroForwardRecoveryAction.resumeFromNextBufferedChunk) {
       return;
     }
 
-    final remainingChunks = _activeChunks.sublist(nextChunkIndex);
-    _currentQueueBaseIndex = nextChunkIndex;
-    _currentChunkIndex = nextChunkIndex;
+    final nextChunkIndex = recoveryPlan.nextChunkIndex!;
+    final nextRelativeIndex = nextChunkIndex - _currentQueueBaseIndex;
     _waitingForUnderrunRecovery = false;
+    _currentChunkIndex = nextChunkIndex;
 
     await _player.setVolume(_volume);
-    await _player.stop();
-    await _player.setAudioSources(
-      remainingChunks
-          .map((chunk) => AudioSource.file(chunk.filePath))
-          .toList(growable: false),
-    );
-    await _player.seek(Duration.zero, index: 0);
+    await _player.seek(Duration.zero, index: nextRelativeIndex);
     _emitProgressForChunkWord(nextChunkIndex, 0, elapsedInChunk: Duration.zero);
     _emitActivity(
-      TtsPlaybackActivity(
-        phase: TtsPlaybackPhase.playing,
-        bufferedChunkCount: remainingChunks.length,
+      _playbackActivityForPhase(
+        TtsPlaybackPhase.playing,
+        bufferedChunkCount: _activeChunks.length - nextChunkIndex,
         totalChunkCount: _expectedChunkCount,
       ),
     );
     await _player.play();
+  }
+
+  Future<void> _awaitStartupWarmup({
+    required _PlaybackChunk firstChunk,
+  }) async {
+    final deadline = DateTime.now().add(_startupWarmupMaxWait);
+    while (_activeGenerationId != null && _activePlaybackToken == null) {
+      if (_isStartupWarmEnough(firstChunk)) {
+        return;
+      }
+      if (DateTime.now().isAfter(deadline)) {
+        _recordMetric(
+          'startupWarmupTimedOut',
+          chunkId: firstChunk.chunkId,
+          voiceId: firstChunk.voiceId,
+          value: <String, Object?>{
+            'bufferedChunkCount': _startupBufferedChunks(firstChunk).length,
+            'pendingChunkCount': _pendingChunksById.length,
+            'remainingPlannedChunkCount': _remainingPlannedChunkCount,
+          },
+        );
+        return;
+      }
+      await Future<void>.delayed(_startupWarmupPollInterval);
+    }
+  }
+
+  bool _isStartupWarmEnough(_PlaybackChunk firstChunk) {
+    final startupBufferedChunks = _startupBufferedChunks(firstChunk);
+    return kokoroIsStartupWarmEnough(
+      bufferedChunkCount: startupBufferedChunks.length,
+      bufferedLeadTime: _initialBufferedQueueLeadTime(startupBufferedChunks),
+      pendingChunkCount: _pendingChunksById.length,
+      remainingPlannedChunkCount: _remainingPlannedChunkCount,
+    );
+  }
+
+  List<_PlaybackChunk> _startupBufferedChunks(_PlaybackChunk firstChunk) {
+    return kokoroBuildInitialPlaybackQueue(
+      firstChunk: firstChunk,
+      stagedChunks: _stagedReadyChunks,
+      chunkIdOf: (chunk) => chunk.chunkId,
+      startWordIndexOf: (chunk) => chunk.startWordIndex,
+      startOffsetOf: (chunk) => chunk.startOffset,
+    );
+  }
+
+  void _stageReadyChunk(_PlaybackChunk playbackChunk) {
+    final existingIndex = _stagedReadyChunks.indexWhere(
+      (chunk) => chunk.chunkId == playbackChunk.chunkId,
+    );
+    if (existingIndex >= 0) {
+      _stagedReadyChunks[existingIndex] = playbackChunk;
+    } else {
+      _stagedReadyChunks.add(playbackChunk);
+    }
+    _stagedReadyChunks.sort(_comparePlaybackChunkOrder);
+  }
+
+  List<_PlaybackChunk> _drainStagedReadyChunks() {
+    if (_stagedReadyChunks.isEmpty) {
+      return const <_PlaybackChunk>[];
+    }
+    final drained = List<_PlaybackChunk>.from(_stagedReadyChunks);
+    _stagedReadyChunks.clear();
+    return drained;
+  }
+
+  Future<void> _flushStagedReadyChunksToActiveQueue({
+    required String generationId,
+  }) async {
+    final stagedChunks = _drainStagedReadyChunks();
+    for (final chunk in stagedChunks) {
+      await _appendReadyChunkToActiveQueue(chunk, generationId: generationId);
+    }
+  }
+
+  Future<void> _appendReadyChunkToActiveQueue(
+    _PlaybackChunk playbackChunk, {
+    required String? generationId,
+  }) async {
+    _audioQueueMutation = _audioQueueMutation.then((_) async {
+      if (generationId != _activeGenerationId) {
+        return;
+      }
+      if (_activePlaybackToken == null) {
+        _stageReadyChunk(playbackChunk);
+        return;
+      }
+      if (_activeChunks.any((chunk) => chunk.chunkId == playbackChunk.chunkId)) {
+        return;
+      }
+
+      final insertIndex = kokoroPlaybackInsertIndex<_PlaybackChunk>(
+        activeChunks: _activeChunks,
+        incomingChunk: playbackChunk,
+        chunkIdOf: (chunk) => chunk.chunkId,
+        startWordIndexOf: (chunk) => chunk.startWordIndex,
+        startOffsetOf: (chunk) => chunk.startOffset,
+      );
+      if (insertIndex <= _currentChunkIndex) {
+        _recordMetric(
+          'lateChunkDiscarded',
+          chunkId: playbackChunk.chunkId,
+          voiceId: playbackChunk.voiceId,
+          value: <String, Object?>{
+            'insertIndex': insertIndex,
+            'currentChunkIndex': _currentChunkIndex,
+            'startWordIndex': playbackChunk.startWordIndex,
+          },
+        );
+        return;
+      }
+
+      final previousActiveChunkCount = _activeChunks.length;
+      _activeChunks = List<_PlaybackChunk>.from(_activeChunks)
+        ..insert(insertIndex, playbackChunk);
+      final relativeInsertIndex = insertIndex - _currentQueueBaseIndex;
+      if (relativeInsertIndex >= previousActiveChunkCount) {
+        await _player.addAudioSource(AudioSource.file(playbackChunk.filePath));
+      } else {
+        await _player.insertAudioSource(
+          relativeInsertIndex,
+          AudioSource.file(playbackChunk.filePath),
+        );
+      }
+      _recordMetric(
+        'prefetchLeadTimeMs',
+        chunkId: playbackChunk.chunkId,
+        voiceId: playbackChunk.voiceId,
+        value: <String, Object?>{
+          'leadTimeMs': _bufferedLeadTime().inMilliseconds,
+          'insertIndex': insertIndex,
+          'activeChunkCount': _activeChunks.length,
+        },
+      );
+      _emitActivity(
+        _playbackActivityForPhase(
+          TtsPlaybackPhase.playing,
+          bufferedChunkCount: _activeChunks.length,
+          totalChunkCount: _expectedChunkCount,
+        ),
+      );
+    });
+    await _audioQueueMutation;
+  }
+
+  Future<void> _discardFutureBufferedChunksFromStartWordIndex(
+    int replacementStartWordIndex,
+  ) async {
+    _audioQueueMutation = _audioQueueMutation.then((_) async {
+      final pruneIndex = kokoroFirstFutureReplacementIndex<_PlaybackChunk>(
+        activeChunks: _activeChunks,
+        currentChunkIndex: _currentChunkIndex,
+        replacementStartWordIndex: replacementStartWordIndex,
+        startWordIndexOf: (chunk) => chunk.startWordIndex,
+      );
+      if (pruneIndex == null) {
+        return;
+      }
+
+      final prunedChunks = _activeChunks.sublist(pruneIndex);
+      _activeChunks = List<_PlaybackChunk>.from(_activeChunks.take(pruneIndex));
+      if (_activePlaybackToken != null) {
+        final startRelativeIndex = pruneIndex - _currentQueueBaseIndex;
+        final endRelativeIndex = startRelativeIndex + prunedChunks.length;
+        await _player.removeAudioSourceRange(
+          startRelativeIndex,
+          endRelativeIndex,
+        );
+      }
+
+      _recordMetric(
+        'futureBufferedChunksPruned',
+        value: <String, Object?>{
+          'replacementStartWordIndex': replacementStartWordIndex,
+          'pruneIndex': pruneIndex,
+          'prunedChunkIds': prunedChunks
+              .map((chunk) => chunk.chunkId)
+              .toList(growable: false),
+        },
+      );
+    });
+    await _audioQueueMutation;
   }
 
   KokoroPlaybackQueueSnapshot _playbackQueueSnapshot() {
@@ -1808,6 +2084,46 @@ class KokoroTtsEngine
 
   void _emitActivity(TtsPlaybackActivity activity) {
     _onActivity?.call(activity);
+  }
+
+  TtsPlaybackActivity _playbackActivityForPhase(
+    TtsPlaybackPhase phase, {
+    int bufferedChunkCount = 0,
+    int totalChunkCount = 0,
+  }) {
+    final leadTime = phase == TtsPlaybackPhase.idle
+        ? Duration.zero
+        : _bufferedLeadTime();
+    final pressure = phase == TtsPlaybackPhase.idle
+        ? TtsBufferPressure.none
+        : kokoroBufferPressureForLeadTime(leadTime);
+
+    if (phase != TtsPlaybackPhase.idle &&
+        pressure != _lastRecordedBufferPressure) {
+      _recordMetric(
+        'bufferPressureState',
+        value: <String, Object?>{
+          'state': pressure.name,
+          'leadTimeMs': leadTime.inMilliseconds,
+          'targetLeadTimeMs': kokoroTargetBufferedLeadTime.inMilliseconds,
+          'lowWaterLeadTimeMs':
+              kokoroLowWaterBufferedLeadTime.inMilliseconds,
+          'criticalLeadTimeMs':
+              kokoroCriticalBufferedLeadTime.inMilliseconds,
+        },
+      );
+      _lastRecordedBufferPressure = pressure;
+    } else if (phase == TtsPlaybackPhase.idle) {
+      _lastRecordedBufferPressure = TtsBufferPressure.none;
+    }
+
+    return TtsPlaybackActivity(
+      phase: phase,
+      bufferedChunkCount: bufferedChunkCount,
+      totalChunkCount: totalChunkCount,
+      bufferPressure: pressure,
+      bufferedLeadTime: leadTime,
+    );
   }
 
   Future<KokoroSpeechWorkerChunkProcessor> _createWorkerProcessor(
@@ -2168,6 +2484,28 @@ class _PlaybackChunk {
   }
 }
 
+int _comparePlaybackChunkOrder(_PlaybackChunk left, _PlaybackChunk right) {
+  final startWordComparison = left.startWordIndex.compareTo(right.startWordIndex);
+  if (startWordComparison != 0) {
+    return startWordComparison;
+  }
+  final startOffsetComparison = left.startOffset.compareTo(right.startOffset);
+  if (startOffsetComparison != 0) {
+    return startOffsetComparison;
+  }
+  return left.chunkId.compareTo(right.chunkId);
+}
+
+Duration _initialBufferedQueueLeadTime(List<_PlaybackChunk> chunks) {
+  if (chunks.isEmpty) {
+    return Duration.zero;
+  }
+  return chunks.fold(
+    Duration.zero,
+    (total, chunk) => total + chunk.duration,
+  );
+}
+
 class _ChunkUnit {
   const _ChunkUnit({required this.text, required this.startOffset});
 
@@ -2182,6 +2520,16 @@ class _PreparedPlannedChunk {
   });
 
   final _QueuedChunk chunk;
+  final int nextSearchOffset;
+}
+
+class _PreparedPlannedChunkWindow {
+  const _PreparedPlannedChunkWindow({
+    required this.chunks,
+    required this.nextSearchOffset,
+  });
+
+  final List<_QueuedChunk> chunks;
   final int nextSearchOffset;
 }
 
@@ -2300,8 +2648,22 @@ int _findChunkStartOffset({
   required int searchOffset,
   required String chunkText,
 }) {
-  final index = fullText.indexOf(chunkText, searchOffset);
-  return index >= 0 ? index : searchOffset;
+  final safeSearchOffset = searchOffset.clamp(0, fullText.length).toInt();
+  final index = fullText.indexOf(chunkText, safeSearchOffset);
+  if (index >= 0) {
+    return index;
+  }
+  final fallbackIndex = fullText.indexOf(chunkText);
+  return fallbackIndex >= 0 ? fallbackIndex : safeSearchOffset;
+}
+
+int _nextChunkSearchOffset({
+  required int fullTextLength,
+  required int startOffset,
+  required int chunkTextLength,
+}) {
+  final rawNextOffset = startOffset + chunkTextLength;
+  return rawNextOffset.clamp(0, fullTextLength).toInt();
 }
 
 String _fallbackCacheKey(

--- a/lib/src/services/tts_engine.dart
+++ b/lib/src/services/tts_engine.dart
@@ -40,12 +40,15 @@ class TtsProgressUpdate {
 }
 
 enum TtsPlaybackPhase { idle, buffering, playing }
+enum TtsBufferPressure { none, healthy, lowWater, critical }
 
 class TtsPlaybackActivity {
   const TtsPlaybackActivity({
     required this.phase,
     this.bufferedChunkCount = 0,
     this.totalChunkCount = 0,
+    this.bufferPressure = TtsBufferPressure.none,
+    this.bufferedLeadTime = Duration.zero,
     this.message,
   });
 
@@ -53,15 +56,24 @@ class TtsPlaybackActivity {
     : phase = TtsPlaybackPhase.idle,
       bufferedChunkCount = 0,
       totalChunkCount = 0,
+      bufferPressure = TtsBufferPressure.none,
+      bufferedLeadTime = Duration.zero,
       message = null;
 
   final TtsPlaybackPhase phase;
   final int bufferedChunkCount;
   final int totalChunkCount;
+  final TtsBufferPressure bufferPressure;
+  final Duration bufferedLeadTime;
   final String? message;
 
   bool get isBuffering => phase == TtsPlaybackPhase.buffering;
   bool get isPlaying => phase == TtsPlaybackPhase.playing;
+  bool get isAudioUnderPressure =>
+      bufferPressure == TtsBufferPressure.lowWater ||
+      bufferPressure == TtsBufferPressure.critical;
+  bool get isAudioInCriticalPressure =>
+      bufferPressure == TtsBufferPressure.critical;
 }
 
 class TtsDebugTraceSnapshot {

--- a/project/architecture/playback-orchestration-and-synthesis-boundaries.md
+++ b/project/architecture/playback-orchestration-and-synthesis-boundaries.md
@@ -1,6 +1,6 @@
 # Playback Orchestration and Synthesis Boundaries
 
-Last updated: April 4, 2026
+Last updated: April 8, 2026
 Status: Active architecture
 
 ## Purpose
@@ -89,6 +89,7 @@ Responsibilities:
 - hold prepared chunk sequence for the current session
 - start when the first chunk is ready
 - continue while later chunks are still being prepared
+- preserve uninterrupted forward audio whenever prepared audio still exists
 
 ### Progress Mapper
 
@@ -97,6 +98,7 @@ Responsibilities:
 - translate active playback back into segment ids and word ranges
 - support visible spoken-text highlighting
 - support 30-second jump estimation and recovery
+- behave as a follower channel behind active audio rather than as a co-owner of playback
 
 ## Relationships
 
@@ -206,6 +208,33 @@ Reason:
 - narration quality must be evaluated in paragraph and session context, not only in isolated chunk generation
 - subjective listening review needs runtime metrics to stay actionable during implementation
 
+### 6. Speech audio is the uninterrupted primary channel
+
+The system must treat active speech audio as the authoritative real-time rail for a playback session.
+
+That means:
+
+- audio owns the session clock while playback is active
+- progress mapping follows audio
+- reader highlighting and viewport behavior follow mapped progress
+- follower state may lag, coalesce, or jump forward to catch up
+
+Reason:
+
+- speech is temporally sensitive in a way that follow-along visuals are not
+- small interruptions in audio are more damaging than skipped intermediate highlight states
+- the user can tolerate visible catch-up much more easily than audible stutter
+
+### 7. Ordinary forward playback queue mutation is append-only
+
+While session identity is unchanged and prepared audio still exists ahead of the playhead, ordinary later-chunk arrival must not rebuild active playback.
+
+Reason:
+
+- `stop -> setAudioSources -> seek -> play` is an audible interruption pattern
+- queue mutation should extend forward playback rather than restart it
+- later chunk readiness is not, by itself, a transport event
+
 ## Architectural Rules
 
 - The first playback action waits only for first-chunk readiness.
@@ -218,12 +247,16 @@ Reason:
 - Completed chunks are not deleted just because playback is paused, replayed, or jumped.
 - Boundary policy is applied before a chunk is treated as final cache content.
 - Boundary policy uses trim-and-cap joins by default and does not add blind player-level gaps.
+- Active speech audio is the authoritative session clock while playback is running.
+- Progress mapping, highlighting, follow-along, diagnostics, and resume persistence are follower concerns and must not stop, rebuild, or restart active playback.
+- Ordinary forward queue growth is append-only while session identity is unchanged.
+- If follower presentation falls behind audio, the system must prefer coalescing or resynchronizing the follower state over interrupting audio.
 - Progress mapping stays tied to normalized content ids, not only elapsed audio time.
 - Highlighting and reading-focus behavior consume progress mapping output rather than reparsing display HTML.
 
 ## Current Implementation Gap
 
-The current implementation now satisfies most of this architecture for the active engine path, with a few remaining gaps:
+The current implementation now satisfies much of this architecture for the active engine path, with a few remaining gaps:
 
 - first-chunk startup, background preparation, finalized chunk reuse, boundary correction, and playback instrumentation are all first-class in code
 - document-open priming and runtime scheduling now keep playback smooth, but long-form prosody richness remains narrower than the target architecture
@@ -231,6 +264,8 @@ The current implementation now satisfies most of this architecture for the activ
 - the progress mapper now drives spoken highlighting and reading-focus behavior on the reader surface
 - file-backed continuity now restores the last heard reading position when recovery is possible, and watched-file live input preserves playing-versus-paused semantics across refresh
 - current controller code still leans on compatibility text views in `ReaderDocument` while normalized mappings remain the underlying source of truth
+- the active Kokoro path still allows player-source rebuilding during underrun recovery, which violates the new audio-authoritative target for ordinary forward playback
+- follower progress and visible follow-along behavior do not yet have an explicit coalescing and hard-resynchronization policy under load
 
 ## Governing Specifications
 
@@ -240,6 +275,7 @@ The current implementation now satisfies most of this architecture for the activ
 - [Generated Audio Cache](../specifications/generated-audio-cache.md)
 - [Synthesis Boundary Policy](../specifications/synthesis-boundary-policy.md)
 - [Playback Coordination](../specifications/playback-coordination.md)
+- [Audio-Authoritative Playback Synchronization](../specifications/audio-authoritative-playback-synchronization.md)
 - [Playback Progress and Jump Mapping](../specifications/playback-progress-and-jump-mapping.md)
 - [Spoken Text Highlighting and Reading Focus](../specifications/spoken-text-highlighting-and-reading-focus.md)
 - [Playback Quality Instrumentation](../specifications/playback-quality-instrumentation.md)

--- a/project/architecture/spoken-text-highlighting-and-reading-focus.md
+++ b/project/architecture/spoken-text-highlighting-and-reading-focus.md
@@ -1,6 +1,6 @@
 # Spoken Text Highlighting and Reading Focus
 
-Last updated: April 3, 2026
+Last updated: April 8, 2026
 Status: Active architecture
 
 ## Purpose
@@ -112,25 +112,39 @@ Reason:
 - some imported formats or future engine paths may have weaker mapping confidence
 - segment or block highlighting is still better than no follow-along state
 
+### 4. Highlight and focus are follower channels, not playback owners
+
+The reader surface must follow the active audio session rather than competing with it.
+
+Reason:
+
+- the user hears stutter more harshly than they notice skipped intermediate highlight states
+- UI update pressure is allowed to degrade gracefully
+- playback continuity and presentation continuity are not equally important
+
 ## Architectural Rules
 
 - Highlight state must derive from normalized ids and ranges.
 - The UI must not re-derive spoken ranges from flattened `displayHtml` or `speakableText`.
 - The mapping layer must support a fallback ladder from word to segment to block.
+- Highlight and focus updates must not block, restart, or indirectly reconfigure active playback.
+- The visible follower path may coalesce, drop intermediate states, or hard-resynchronize to the current audio-mapped position when needed.
 - Viewport follow policy must be explicit and suspendable.
 - Pause must freeze the visible highlight at the last known spoken range until playback resumes or resets.
 
 ## Current Implementation Gap
 
-The core branch is now implemented:
+The core branch is now implemented, but one coordination gap remains open:
 
 - follow-along rendering is active
 - reading focus and recenter behavior are active
 - the reading surface now preserves readable contrast across appearance modes
+- explicit follower coalescing and hard-resynchronization behavior under playback load is still being defined as a focused implementation branch
 
-Future work in this area should focus on additional polish or accessibility improvements rather than missing core branch behavior.
+Future work in this area should focus on follower catch-up behavior under load plus later polish or accessibility improvements.
 
 ## Governing Specifications
 
 - [Playback Progress and Jump Mapping](../specifications/playback-progress-and-jump-mapping.md)
 - [Spoken Text Highlighting and Reading Focus](../specifications/spoken-text-highlighting-and-reading-focus.md)
+- [Follower Progress Coalescing And Drift Resynchronization](../specifications/follower-progress-coalescing-and-drift-resynchronization.md)

--- a/project/planning/progression.md
+++ b/project/planning/progression.md
@@ -1,6 +1,6 @@
 # Progression
 
-Last updated: April 7, 2026
+Last updated: April 8, 2026
 Status: Active progression
 
 ## Purpose
@@ -155,16 +155,26 @@ Test specification checkboxes track verification work against the paired documen
 - [x] [Initial and Resumed Boundary Handling](../specifications/initial-and-resumed-boundary-handling.md)
 - [x] [Boundary-Corrected Chunk Output and Reuse](../specifications/boundary-corrected-chunk-output-and-reuse.md)
 - [x] [Playback Coordination](../specifications/playback-coordination.md)
+- [x] [Uninterrupted Audio Primary Channel](../specifications/uninterrupted-audio-primary-channel.md)
+- [x] [Append-Only Forward Playback Queue](../specifications/append-only-forward-playback-queue.md)
+- [x] [Buffered Lead-Time And Underrun Policy](../specifications/buffered-lead-time-and-underrun-policy.md)
 - [x] [Playback Progress and Jump Mapping](../specifications/playback-progress-and-jump-mapping.md)
 - [x] [Document Replacement Playback Reset And Stale Event Rejection](../specifications/document-replacement-playback-reset-and-stale-event-rejection.md)
 - [x] [Spoken Text Selection and Display Mapping](../specifications/spoken-text-selection-and-display-mapping.md)
+- [x] [Follower Progress Coalescing And Drift Resynchronization](../specifications/follower-progress-coalescing-and-drift-resynchronization.md)
 - [x] [Reading Focus Follow Policy](../specifications/reading-focus-follow-policy.md)
+- [x] [Running-App Uninterrupted Speech Under Follow-Along Load](../specifications/running-app-uninterrupted-speech-under-follow-along-load.md)
 
 #### Test Specifications
 
 - [x] [Test Specification: Playback Coordination](../test-specifications/playback-coordination.md)
+- [x] [Test Specification: Uninterrupted Audio Primary Channel](../test-specifications/uninterrupted-audio-primary-channel.md)
+- [x] [Test Specification: Append-Only Forward Playback Queue](../test-specifications/append-only-forward-playback-queue.md)
+- [x] [Test Specification: Buffered Lead-Time And Underrun Policy](../test-specifications/buffered-lead-time-and-underrun-policy.md)
 - [x] [Test Specification: Playback Progress And Jump Mapping](../test-specifications/playback-progress-and-jump-mapping.md)
 - [x] [Test Specification: Document Replacement Playback Reset And Stale Event Rejection](../test-specifications/document-replacement-playback-reset-and-stale-event-rejection.md)
+- [x] [Test Specification: Follower Progress Coalescing And Drift Resynchronization](../test-specifications/follower-progress-coalescing-and-drift-resynchronization.md)
+- [x] [Test Specification: Running-App Uninterrupted Speech Under Follow-Along Load](../test-specifications/running-app-uninterrupted-speech-under-follow-along-load.md)
 
 ### App Shell And Platform Navigation UI
 

--- a/project/specifications/README.md
+++ b/project/specifications/README.md
@@ -244,6 +244,16 @@ They are intentionally narrower than architecture documents. For any architectur
 
 ### Playback Coordination
 
+- [Audio-Authoritative Playback Synchronization](audio-authoritative-playback-synchronization.md)
+  Umbrella specification for making active speech audio authoritative while progress and reader presentation follow behind it.
+- [Uninterrupted Audio Primary Channel](uninterrupted-audio-primary-channel.md)
+  Defines the ownership rule that active speech audio is the authoritative session channel and follower concerns stay downstream.
+- [Append-Only Forward Playback Queue](append-only-forward-playback-queue.md)
+  Defines append-only queue growth during ordinary forward playback.
+- [Buffered Lead-Time And Underrun Policy](buffered-lead-time-and-underrun-policy.md)
+  Defines explicit lead-time thresholds, scheduler reaction, and true underrun recovery behavior.
+- [Running-App Uninterrupted Speech Under Follow-Along Load](running-app-uninterrupted-speech-under-follow-along-load.md)
+  Defines the surfaced running-app outcome that speech stays smooth even when the reader surface must catch up.
 - [Playback Coordination](playback-coordination.md)
   Defines controller state, transport behavior, replay semantics, jump handling, and sleep fade behavior.
 - [Playback Progress and Jump Mapping](playback-progress-and-jump-mapping.md)
@@ -254,6 +264,8 @@ They are intentionally narrower than architecture documents. For any architectur
   Umbrella specification for spoken selection derivation, display mapping, and reading-focus follow behavior.
 - [Spoken Text Selection and Display Mapping](spoken-text-selection-and-display-mapping.md)
   Defines how playback progress becomes a mapped visible spoken selection.
+- [Follower Progress Coalescing And Drift Resynchronization](follower-progress-coalescing-and-drift-resynchronization.md)
+  Defines how the visible follower path may coalesce or hard-resynchronize when it falls behind active audio.
 - [Reading Focus Follow Policy](reading-focus-follow-policy.md)
   Defines how the reader viewport follows playback and yields to user scrolling.
 - [Playback Quality Instrumentation](playback-quality-instrumentation.md)

--- a/project/specifications/append-only-forward-playback-queue.md
+++ b/project/specifications/append-only-forward-playback-queue.md
@@ -1,0 +1,56 @@
+# Append-Only Forward Playback Queue
+
+Last updated: April 8, 2026
+Status: Final specification
+
+## Overview
+
+This specification defines how the active playback queue must behave while forward playback continues under one unchanged session identity.
+
+## Backlink
+
+Parent specification:
+
+- [Audio-Authoritative Playback Synchronization](audio-authoritative-playback-synchronization.md)
+
+## Scope
+
+This specification covers:
+
+- queue mutation while a session is actively playing forward
+- later-chunk arrival during active playback
+- the boundary between normal queue growth and true queue rebuilds
+
+## Behavior
+
+Once the first chunk of an active session is playing:
+
+- later prepared chunks append behind the playhead in playback order
+- ordinary later-chunk readiness must extend the queue rather than rebuilding it
+- already consumed chunks may fall out of the live queue bookkeeping without disturbing future playback order
+
+Ordinary forward playback must not use a full player-source rebuild merely because:
+
+- a later chunk became ready
+- progress mapping advanced
+- highlight or follow state changed
+- follower state needed to catch up
+
+Player-source replacement or queue rebuild is allowed only when:
+
+- session identity changes because of jump, rate, voice, replay, or document replacement
+- or true starvation recovery is required after prepared audio has already been exhausted
+
+Even in starvation recovery, the system must resume from the next unplayed audio point rather than replaying already consumed content.
+
+## Constraints
+
+- later chunk arrival alone is not a transport event
+- forward playback order must remain monotonic within a session
+- queue bookkeeping may change, but ordinary forward audio continuity must remain the priority
+
+## Acceptance
+
+- normal forward playback extends by appending future chunks behind active audio
+- ordinary later-chunk readiness does not require `stop -> setAudioSources -> seek -> play`
+- if queue rebuild is still required after true starvation, recovery resumes from the next unplayed point instead of replaying earlier audio

--- a/project/specifications/audio-authoritative-playback-synchronization.md
+++ b/project/specifications/audio-authoritative-playback-synchronization.md
@@ -1,0 +1,59 @@
+# Audio-Authoritative Playback Synchronization
+
+Last updated: April 8, 2026
+Status: Draft specification
+
+## Overview
+
+This specification defines the focused rearchitecture work needed to make active speech audio the authoritative playback channel while progress mapping and reader presentation follow behind it.
+
+## Backlink
+
+Parent specification:
+
+- [Imported Document Playback](imported-document-playback.md)
+
+## Scope
+
+This specification covers:
+
+- audio-session authority during active playback
+- forward queue mutation rules while a session is playing
+- buffered lead-time and underrun policy
+- the surfaced running-app expectation that follow-along must not make speech stutter
+
+## Behavior
+
+This parent branch now delegates detailed implementation to child specifications.
+
+In particular:
+
+- uninterrupted audio authority belongs to its own leaf
+- append-only forward queue behavior belongs to its own leaf
+- buffered lead-time and underrun policy belong to their own leaf
+- the observable running-app outcome belongs to its own surfaced leaf
+
+This parent specification keeps only the branch-level contract that active speech audio is the authoritative real-time rail, while progress mapping and reader presentation are follower channels that may lag, coalesce, or resynchronize without interrupting audio.
+
+## Constraints
+
+- active speech audio owns the session clock while playback is running
+- non-transport follower behavior must not stop, rebuild, or restart active playback
+- ordinary forward queue growth must preserve monotonic playback order
+- if follower state falls behind, the system must prefer visible catch-up over audible interruption
+
+## Refinement Status
+
+Refinement complete for the current planned branch.
+
+## Child Specifications
+
+- [Uninterrupted Audio Primary Channel](uninterrupted-audio-primary-channel.md)
+- [Append-Only Forward Playback Queue](append-only-forward-playback-queue.md)
+- [Buffered Lead-Time And Underrun Policy](buffered-lead-time-and-underrun-policy.md)
+- [Running-App Uninterrupted Speech Under Follow-Along Load](running-app-uninterrupted-speech-under-follow-along-load.md)
+
+## Acceptance
+
+- imported playback explicitly represents audio-authoritative coordination work rather than leaving it implied inside broad transport behavior
+- the remaining work in this branch is represented by final leaf specifications

--- a/project/specifications/buffered-lead-time-and-underrun-policy.md
+++ b/project/specifications/buffered-lead-time-and-underrun-policy.md
@@ -1,0 +1,86 @@
+# Buffered Lead-Time And Underrun Policy
+
+Last updated: April 8, 2026
+Status: Final specification
+
+## Overview
+
+This specification defines the buffer-lead policy that keeps active speech audio ahead of follower work and defines what a real underrun means.
+
+## Backlink
+
+Parent specification:
+
+- [Audio-Authoritative Playback Synchronization](audio-authoritative-playback-synchronization.md)
+
+## Scope
+
+This specification covers:
+
+- buffered lead-time measurement
+- startup playback warmup before first audible speech
+- scheduler reaction to shrinking lead time
+- the difference between follower lag and true audio starvation
+- underrun recovery semantics
+
+## Behavior
+
+The playback system must maintain an explicit estimate of buffered audio lead time ahead of the current playhead.
+
+Initial operating thresholds:
+
+- target buffered lead time: `8` seconds
+- low-water threshold: `4` seconds
+- critical threshold: `2` seconds
+
+When a session is about to start playback and future chunks are still expected:
+
+- the system must prefer a short startup warmup over starting audible speech with only a fragile first chunk buffered
+- startup may wait for additional prepared audio before the first `play`
+- startup is warm enough once either:
+  - enough buffered lead exists to meet the startup runway threshold
+  - or multiple future chunks are already buffered with at least low-water lead
+  - or no further future work remains for that session
+
+Startup warmup exists to reduce first-paragraph stutter and early queue starvation.
+
+When lead time falls below the low-water threshold:
+
+- next-chunk preparation gains highest ordinary scheduling priority
+- instrumentation records the reduced lead time
+- follower behavior remains best-effort and must not steal control from the audio rail
+
+When lead time falls below the critical threshold:
+
+- the system treats future audio continuity as the dominant scheduling concern
+- nonessential follower catch-up work may be coalesced or skipped
+
+A true underrun exists only when active playback runs out of prepared audio.
+
+The following are not underruns:
+
+- highlight lag
+- reading-focus lag
+- delayed resume persistence
+- delayed diagnostics updates
+
+When a true underrun occurs:
+
+- the system may surface buffering state
+- the system must not emit silent progress or highlight loops over already spoken content
+- recovery resumes from the next unplayed audio point once enough audio exists again
+- follower state resynchronizes to recovered audio rather than trying to replay missed visual steps
+
+## Constraints
+
+- lead-time policy must be observable through instrumentation
+- follower lag must not be misclassified as audio starvation
+- ordinary scheduler behavior must prefer preserving buffered audio over preserving every intermediate visual state
+
+## Acceptance
+
+- buffered lead time has explicit target, low-water, and critical thresholds
+- scheduler behavior is defined for shrinking lead time
+- startup playback waits for a real initial runway when future chunks are still being prepared
+- real underruns are distinguished from UI lag
+- underrun recovery no longer permits silent highlight-only catch-up as a valid mode

--- a/project/specifications/follower-progress-coalescing-and-drift-resynchronization.md
+++ b/project/specifications/follower-progress-coalescing-and-drift-resynchronization.md
@@ -1,0 +1,58 @@
+# Follower Progress Coalescing And Drift Resynchronization
+
+Last updated: April 8, 2026
+Status: Final specification
+
+## Overview
+
+This specification defines how visible spoken selection and reader follow-along should behave when the follower side cannot keep pace with the active audio session.
+
+## Backlink
+
+Parent specification:
+
+- [Spoken Text Highlighting and Reading Focus](spoken-text-highlighting-and-reading-focus.md)
+
+## Scope
+
+This specification covers:
+
+- visible spoken-selection update cadence
+- dropping or coalescing intermediate follower states
+- hard resynchronization when visible state drifts too far behind audio
+
+## Behavior
+
+Spoken-selection and follow-along updates are follower updates behind active audio.
+
+The follower path may:
+
+- coalesce multiple progress events into one visible update
+- drop intermediate word-level states when later progress has already arrived
+- jump directly to the current audio-mapped position when drift becomes too large
+
+Initial follower policy:
+
+- visible follower updates should not exceed `15` updates per second during ordinary playback
+- if visible follower lag exceeds roughly `250` milliseconds of audio progress, the system may skip intermediate visible states
+- if the visible region drifts by more than `10` words or by more than one display block, the system may hard-resynchronize to the current mapped audio position
+
+Follower catch-up must not:
+
+- request playback restart
+- request queue rebuild
+- replay missed highlight states
+
+If the mapping layer temporarily loses precise word confidence, the reader may preserve the last stable state briefly and then resynchronize using segment- or block-level fallback.
+
+## Constraints
+
+- coalescing policy must preserve understandable follow-along behavior
+- hard resynchronization must favor current audio truth over historical visual continuity
+- follower recovery must remain downstream of normalized mapping rather than ad hoc renderer search
+
+## Acceptance
+
+- the reader surface can skip intermediate visible updates without losing the current spoken region entirely
+- visible spoken selection can hard-resynchronize to current audio position when follower drift grows too large
+- follower catch-up behavior no longer depends on trying to preserve every intermediate highlight step

--- a/project/specifications/imported-document-playback.md
+++ b/project/specifications/imported-document-playback.md
@@ -1,6 +1,6 @@
 # Imported Document Playback
 
-Last updated: April 3, 2026
+Last updated: April 8, 2026
 Status: Draft specification
 
 ## Scope
@@ -26,6 +26,7 @@ Detailed implementation specifications:
 - [Generated Audio Cache](generated-audio-cache.md)
 - [Synthesis Boundary Policy](synthesis-boundary-policy.md)
 - [Playback Coordination](playback-coordination.md)
+- [Audio-Authoritative Playback Synchronization](audio-authoritative-playback-synchronization.md)
 - [Playback Progress and Jump Mapping](playback-progress-and-jump-mapping.md)
 - [Document Replacement Playback Reset And Stale Event Rejection](document-replacement-playback-reset-and-stale-event-rejection.md)
 - [Playback Quality Instrumentation](playback-quality-instrumentation.md)
@@ -40,6 +41,7 @@ In particular:
 - first-chunk startup behavior belongs to its own leaf
 - responsiveness policy for ordinary imported documents belongs to its own leaf
 - realization, generation, boundary, progress, and controller transport behavior belong to their respective leaves
+- audio-authoritative playback synchronization belongs to its own branch because uninterrupted speech requires stricter coordination rules than ordinary transport state alone
 - file-backed reader continuity and watched-file live input belong to their own leaf because they change how imported content is refreshed without changing the shared speech pipeline
 - remembered last-heard position and startup resume belong to the reader-continuity branch rather than being left implicit
 
@@ -60,6 +62,7 @@ This is a draft umbrella specification. Its child specifications are expected to
 - [Generated Audio Cache](generated-audio-cache.md)
 - [Synthesis Boundary Policy](synthesis-boundary-policy.md)
 - [Playback Coordination](playback-coordination.md)
+- [Audio-Authoritative Playback Synchronization](audio-authoritative-playback-synchronization.md)
 - [Playback Progress and Jump Mapping](playback-progress-and-jump-mapping.md)
 - [Document Replacement Playback Reset And Stale Event Rejection](document-replacement-playback-reset-and-stale-event-rejection.md)
 - [Playback Quality Instrumentation](playback-quality-instrumentation.md)

--- a/project/specifications/running-app-uninterrupted-speech-under-follow-along-load.md
+++ b/project/specifications/running-app-uninterrupted-speech-under-follow-along-load.md
@@ -1,0 +1,51 @@
+# Running-App Uninterrupted Speech Under Follow-Along Load
+
+Last updated: April 8, 2026
+Status: Final specification
+
+## Overview
+
+This specification defines the user-observable outcome of the audio-authoritative rearchitecture during ordinary running-app playback.
+
+## Backlink
+
+Parent specification:
+
+- [Audio-Authoritative Playback Synchronization](audio-authoritative-playback-synchronization.md)
+
+## Scope
+
+This specification covers:
+
+- live playback with spoken highlighting active
+- playback while the reader surface follows or catches up
+- ordinary later-chunk arrival during long-form reading
+
+## Behavior
+
+In the running app, ordinary reading with active follow-along must preserve audible speech continuity as the primary experience.
+
+During active playback:
+
+- speech must continue smoothly while highlighting and follow-along update
+- if the visible reader surface falls behind, it may skip intermediate states and catch up to the current spoken region
+- visible catch-up may appear as a jump to the current audio position when needed
+
+The system must not prefer preserving every intermediate highlight step over preserving audible continuity.
+
+Ordinary follow-along load must not create:
+
+- repeated audible stutter caused by coordination between text and audio
+- silent highlight-only loops over already spoken content
+- a required user pause/play intervention to keep speech moving
+
+## Constraints
+
+- this is a surfaced running-app behavior, not only an internal queue rule
+- acceptance must be satisfied by the observed app experience rather than by isolated controller state alone
+
+## Acceptance
+
+- with follow-along active during ordinary long-form playback, speech remains audibly continuous while visible text remains reasonably aligned
+- if the reader surface cannot keep up, the visible spoken region catches up by skipping or jumping forward rather than by making speech stutter
+- the running app no longer requires manual intervention to continue ordinary playback after text-side coordination pressure

--- a/project/specifications/spoken-text-highlighting-and-reading-focus.md
+++ b/project/specifications/spoken-text-highlighting-and-reading-focus.md
@@ -19,6 +19,7 @@ This specification covers:
 - spoken selection derivation
 - progress-to-display mapping
 - reading-focus follow policy
+- follower coalescing and resynchronization when UI state lags active audio
 
 ## Behavior
 
@@ -28,6 +29,7 @@ In particular:
 
 - spoken selection and display mapping belong to one leaf
 - reading-focus follow policy belongs to its own leaf
+- follower progress coalescing and drift resynchronization belong to their own leaf
 
 This parent specification keeps only the branch-level contract that playback progress must become visible follow-along state on the reader surface.
 
@@ -36,6 +38,7 @@ This parent specification keeps only the branch-level contract that playback pro
 - spoken highlight state must remain traceable to normalized ids
 - degraded mapping must still result in useful UI feedback
 - highlight behavior must remain engine-agnostic above the progress-event contract
+- highlight and follow-along behavior must remain follower channels behind audio rather than co-owning playback
 
 ## Refinement Status
 
@@ -45,9 +48,11 @@ Refinement complete for the current planned branch.
 
 - [Spoken Text Selection and Display Mapping](spoken-text-selection-and-display-mapping.md)
 - [Reading Focus Follow Policy](reading-focus-follow-policy.md)
+- [Follower Progress Coalescing And Drift Resynchronization](follower-progress-coalescing-and-drift-resynchronization.md)
 
 ## Acceptance
 
 - the reader surface visibly tracks the current spoken text
 - the viewport follows playback without fighting user scrolling
+- follower catch-up behavior under load is represented by its own final leaf rather than being left implicit
 - the remaining work in this branch is represented by final leaf specifications

--- a/project/specifications/uninterrupted-audio-primary-channel.md
+++ b/project/specifications/uninterrupted-audio-primary-channel.md
@@ -1,0 +1,64 @@
+# Uninterrupted Audio Primary Channel
+
+Last updated: April 8, 2026
+Status: Final specification
+
+## Overview
+
+This specification defines the ownership rule that active speech audio is the authoritative playback channel for a session.
+
+## Backlink
+
+Parent specification:
+
+- [Audio-Authoritative Playback Synchronization](audio-authoritative-playback-synchronization.md)
+
+## Scope
+
+This specification covers:
+
+- session-clock authority during active playback
+- the boundary between audio transport ownership and follower concerns
+- which events are allowed to reconfigure active playback
+
+## Behavior
+
+While a playback session is active:
+
+- speech audio owns the authoritative session clock
+- progress mapping follows that audio position
+- highlighting, reading focus, diagnostics, and resume persistence follow mapped progress
+
+The following may create, replace, or deliberately reconfigure the active playback session:
+
+- `play` from `idle`
+- `play` from `completed`
+- `pause`
+- jump actions
+- voice changes
+- rate changes
+- document replacement
+- explicit playback failure handling after audio is no longer available
+
+The following must not stop, rebuild, or restart active playback:
+
+- ordinary progress-event handling
+- highlight derivation
+- reading-focus follow behavior
+- scroll-yield behavior
+- diagnostics or instrumentation writes
+- resume-state persistence
+
+If a follower concern cannot keep pace, audio continues and follower recovery policy handles the resulting lag.
+
+## Constraints
+
+- active audio position is the canonical source of current spoken location
+- follower concerns may observe audio state but do not co-own transport state
+- ordinary follower load must not be treated as a transport conflict
+
+## Acceptance
+
+- the playback system defines one authoritative active-audio channel for a session
+- ordinary progress, highlight, focus, and persistence paths are explicitly downstream of audio rather than peers of it
+- implementation work from this leaf makes it impossible for follower concerns to interrupt active speech audio by default

--- a/project/test-specifications/README.md
+++ b/project/test-specifications/README.md
@@ -59,9 +59,17 @@ This initial backfill focuses on the current running-app feature surface so acti
 - [Document-Specific Cast Voice Assignment Memory](document-specific-cast-voice-assignment-memory.md)
 - [Quoted Dialogue Voice Segmentation](quoted-dialogue-voice-segmentation.md)
 - [Running-App Multi-Voice Playback Switching](running-app-multi-voice-playback-switching.md)
+
+### Playback Coordination And Follower Synchronization
+
 - [Playback Coordination](playback-coordination.md)
+- [Uninterrupted Audio Primary Channel](uninterrupted-audio-primary-channel.md)
+- [Append-Only Forward Playback Queue](append-only-forward-playback-queue.md)
+- [Buffered Lead-Time And Underrun Policy](buffered-lead-time-and-underrun-policy.md)
+- [Running-App Uninterrupted Speech Under Follow-Along Load](running-app-uninterrupted-speech-under-follow-along-load.md)
 - [Playback Progress And Jump Mapping](playback-progress-and-jump-mapping.md)
 - [Document Replacement Playback Reset And Stale Event Rejection](document-replacement-playback-reset-and-stale-event-rejection.md)
+- [Follower Progress Coalescing And Drift Resynchronization](follower-progress-coalescing-and-drift-resynchronization.md)
 
 ### Reader Session And Live Input
 

--- a/project/test-specifications/append-only-forward-playback-queue.md
+++ b/project/test-specifications/append-only-forward-playback-queue.md
@@ -1,0 +1,35 @@
+# Test Specification: Append-Only Forward Playback Queue
+
+Status: final
+
+## Overview
+
+This test specification defines verification for append-only queue growth during ordinary forward playback.
+
+## Backlink
+
+Feature specification:
+
+- [Append-Only Forward Playback Queue](../specifications/append-only-forward-playback-queue.md)
+
+## Manual Smoke Check
+
+1. Start reading a long document and let playback move across multiple chunks.
+2. Keep follow-along visible while later chunks arrive.
+3. Confirm speech continues forward without an audible stop-and-restart feel when later chunks are prepared.
+
+## Automated Smoke Tests
+
+- Simulate first-chunk startup followed by later `chunkReady` events during active playback.
+- Verify later chunk arrival appends future audio instead of rebuilding the whole player source list.
+- Verify player-source replacement remains absent during ordinary forward queue growth.
+
+## Automated Acceptance Tests
+
+- Verify later chunk readiness cannot trigger `stop -> setAudioSources -> seek -> play` while prepared audio still exists for the active session.
+- Verify queue bookkeeping may advance or drop consumed chunks without replaying already spoken audio.
+- Verify true rebuild behavior remains reserved for explicit session changes or confirmed starvation recovery.
+
+## Notes
+
+- This leaf needs explicit player-spy assertions, not only audible regression checks.

--- a/project/test-specifications/buffered-lead-time-and-underrun-policy.md
+++ b/project/test-specifications/buffered-lead-time-and-underrun-policy.md
@@ -1,0 +1,38 @@
+# Test Specification: Buffered Lead-Time And Underrun Policy
+
+Status: final
+
+## Overview
+
+This test specification defines verification for buffered lead-time thresholds, scheduler priority shifts, and true underrun handling.
+
+## Backlink
+
+Feature specification:
+
+- [Buffered Lead-Time And Underrun Policy](../specifications/buffered-lead-time-and-underrun-policy.md)
+
+## Manual Smoke Check
+
+1. Read a long document with ordinary follow-along active.
+2. Confirm the app may briefly show buffering only when audio is actually short, not merely when text catches up.
+3. Confirm any recovery resumes from the next unheard position instead of looping silent highlights.
+
+## Automated Smoke Tests
+
+- Feed queue snapshots with varying buffered lead times and verify low-water and critical policy transitions.
+- Verify startup playback waits for a warm enough initial runway when future chunks are still pending.
+- Verify follower lag does not classify as an underrun.
+- Verify true starvation emits buffering semantics rather than silent highlight-only progression.
+
+## Automated Acceptance Tests
+
+- Verify startup does not begin audible playback with only one fragile chunk buffered when more chunks are still pending.
+- Verify startup may proceed once low-water runway with multiple buffered chunks exists, or once no future work remains.
+- Verify scheduler priority increases when lead time drops below the configured low-water threshold.
+- Verify critical lead-time handling favors preserving future audio over preserving every intermediate follower update.
+- Verify underrun recovery resumes from the next unplayed point and resynchronizes the follower path to that recovered audio position.
+
+## Notes
+
+- Metric and instrumentation assertions should be part of this leaf, not only transport-state assertions.

--- a/project/test-specifications/follower-progress-coalescing-and-drift-resynchronization.md
+++ b/project/test-specifications/follower-progress-coalescing-and-drift-resynchronization.md
@@ -1,0 +1,35 @@
+# Test Specification: Follower Progress Coalescing And Drift Resynchronization
+
+Status: final
+
+## Overview
+
+This test specification defines verification for visible follower coalescing and hard resynchronization when highlight or follow-along state lags active audio.
+
+## Backlink
+
+Feature specification:
+
+- [Follower Progress Coalescing And Drift Resynchronization](../specifications/follower-progress-coalescing-and-drift-resynchronization.md)
+
+## Manual Smoke Check
+
+1. Start playback on a long document with follow-along visible.
+2. Watch the spoken highlight during continuous reading.
+3. Confirm the visible region may skip ahead to the current spoken location rather than trying to animate every intermediate step when the reader surface falls behind.
+
+## Automated Smoke Tests
+
+- Feed rapid progress updates into the follower path and verify visible updates are coalesced to the configured cadence.
+- Verify follower lag can trigger a hard resynchronization without requesting playback restart.
+- Verify lower-confidence mapping can still recover using segment- or block-level fallback.
+
+## Automated Acceptance Tests
+
+- Verify the follower path can drop intermediate word states once lag exceeds the configured threshold.
+- Verify drift beyond the configured word or block threshold causes a direct jump to the current mapped audio position.
+- Verify follower catch-up never replays missed highlight history or requests queue rebuild from the audio side.
+
+## Notes
+
+- Widget tests and controller tests should both participate in this leaf because it crosses visible state and progress policy.

--- a/project/test-specifications/running-app-uninterrupted-speech-under-follow-along-load.md
+++ b/project/test-specifications/running-app-uninterrupted-speech-under-follow-along-load.md
@@ -1,0 +1,35 @@
+# Test Specification: Running-App Uninterrupted Speech Under Follow-Along Load
+
+Status: final
+
+## Overview
+
+This test specification defines verification for the surfaced running-app outcome of the audio-authoritative playback rearchitecture.
+
+## Backlink
+
+Feature specification:
+
+- [Running-App Uninterrupted Speech Under Follow-Along Load](../specifications/running-app-uninterrupted-speech-under-follow-along-load.md)
+
+## Manual Smoke Check
+
+1. Open a long document and enable the normal follow-along reader surface.
+2. Start playback and let it run through multiple later-chunk arrivals while the spoken highlight updates.
+3. Confirm speech stays audibly smooth; if the visible text catches up by jumping, it should do so without making audio stutter.
+
+## Automated Smoke Tests
+
+- Run playback with fake progress pressure and verify audio continuity remains the primary outcome.
+- Verify follower drift recovery does not require a user pause/play cycle.
+- Verify no silent highlight-only loops appear when later chunks or follower work are under pressure.
+
+## Automated Acceptance Tests
+
+- Verify ordinary running-app playback with follow-along active remains audibly continuous across later-chunk arrival and follower catch-up.
+- Verify the visible spoken region may skip intermediate states and still converge on the current audio position.
+- Verify the app no longer requires manual intervention to continue ordinary playback when the follower side briefly falls behind.
+
+## Notes
+
+- This leaf needs real running-app verification by ear in addition to controller and engine coverage.

--- a/project/test-specifications/uninterrupted-audio-primary-channel.md
+++ b/project/test-specifications/uninterrupted-audio-primary-channel.md
@@ -1,0 +1,35 @@
+# Test Specification: Uninterrupted Audio Primary Channel
+
+Status: final
+
+## Overview
+
+This test specification defines verification for the rule that active speech audio remains the authoritative playback channel while follower concerns stay downstream.
+
+## Backlink
+
+Feature specification:
+
+- [Uninterrupted Audio Primary Channel](../specifications/uninterrupted-audio-primary-channel.md)
+
+## Manual Smoke Check
+
+1. Start reading a long document with follow-along active.
+2. While speech is playing, trigger ordinary follower work such as visible highlighting, follow behavior, and resume persistence.
+3. Confirm speech continues without being interrupted by those follower paths.
+
+## Automated Smoke Tests
+
+- Drive active playback while progress, highlight, and persistence callbacks fire repeatedly.
+- Verify ordinary follower callbacks do not issue playback restart, queue rebuild, or transport-reset behavior.
+- Verify only explicit transport or session-changing actions are allowed to create a new playback identity.
+
+## Automated Acceptance Tests
+
+- Verify progress handling, highlight mapping, and resume persistence can all run during active playback without stopping or rebuilding the current audio session.
+- Verify scroll-yield or other follow-along state changes do not change playback identity.
+- Verify voice, rate, jump, replay, and document replacement still remain the only ordinary reasons to reconfigure active playback.
+
+## Notes
+
+- This leaf is best covered by engine and controller tests with fake player/runtime seams plus explicit assertions about forbidden transport mutations.

--- a/test/kokoro_playback_coordination_test.dart
+++ b/test/kokoro_playback_coordination_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:read_aloud/src/services/kokoro_playback_coordination.dart';
+import 'package:read_aloud/src/services/tts_engine.dart';
 
 void main() {
   group('kokoro playback coordination', () {
@@ -61,6 +62,41 @@ void main() {
       expect(kokoroNextRecoveryStartIndex(snapshot), isNull);
     });
 
+    test('plans append-only resume from the next buffered chunk', () {
+      final snapshot = KokoroPlaybackQueueSnapshot(
+        activeChunkCount: 3,
+        currentChunkIndex: 0,
+        currentQueueBaseIndex: 0,
+        pendingChunkCount: 0,
+        remainingPlannedChunkCount: 0,
+        playerRelativeIndex: 0,
+      );
+
+      final plan = kokoroPlanForwardRecovery(snapshot);
+
+      expect(
+        plan.action,
+        KokoroForwardRecoveryAction.resumeFromNextBufferedChunk,
+      );
+      expect(plan.nextChunkIndex, 1);
+    });
+
+    test('waits for prepared audio when starvation has only pending chunks', () {
+      final snapshot = KokoroPlaybackQueueSnapshot(
+        activeChunkCount: 1,
+        currentChunkIndex: 0,
+        currentQueueBaseIndex: 0,
+        pendingChunkCount: 2,
+        remainingPlannedChunkCount: 1,
+        playerRelativeIndex: 0,
+      );
+
+      final plan = kokoroPlanForwardRecovery(snapshot);
+
+      expect(plan.action, KokoroForwardRecoveryAction.waitForPreparedAudio);
+      expect(plan.nextChunkIndex, isNull);
+    });
+
     test('plans recoverable chunk slices on punctuation boundaries', () {
       final slices = kokoroPlanRecoverableChunkSlices(
         wordBoundaries: const <KokoroRecoveryWordBoundary>[
@@ -98,5 +134,175 @@ void main() {
 
       expect(slices, isEmpty);
     });
+
+    test('classifies buffered lead pressure thresholds', () {
+      expect(
+        kokoroBufferPressureForLeadTime(const Duration(seconds: 9)),
+        TtsBufferPressure.healthy,
+      );
+      expect(
+        kokoroBufferPressureForLeadTime(const Duration(seconds: 4)),
+        TtsBufferPressure.lowWater,
+      );
+      expect(
+        kokoroBufferPressureForLeadTime(const Duration(seconds: 2)),
+        TtsBufferPressure.critical,
+      );
+      expect(
+        kokoroBufferPressureForLeadTime(const Duration(milliseconds: 500)),
+        TtsBufferPressure.critical,
+      );
+    });
+
+    test('requires startup warmup when only one short chunk is buffered', () {
+      expect(
+        kokoroIsStartupWarmEnough(
+          bufferedChunkCount: 1,
+          bufferedLeadTime: const Duration(seconds: 3),
+          pendingChunkCount: 2,
+          remainingPlannedChunkCount: 4,
+        ),
+        isFalse,
+      );
+    });
+
+    test('allows startup when enough buffered runway exists', () {
+      expect(
+        kokoroIsStartupWarmEnough(
+          bufferedChunkCount: 2,
+          bufferedLeadTime: const Duration(seconds: 5),
+          pendingChunkCount: 2,
+          remainingPlannedChunkCount: 3,
+        ),
+        isTrue,
+      );
+      expect(
+        kokoroIsStartupWarmEnough(
+          bufferedChunkCount: 1,
+          bufferedLeadTime: const Duration(seconds: 8),
+          pendingChunkCount: 1,
+          remainingPlannedChunkCount: 2,
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not hold startup when no future work remains', () {
+      expect(
+        kokoroIsStartupWarmEnough(
+          bufferedChunkCount: 1,
+          bufferedLeadTime: const Duration(seconds: 2),
+          pendingChunkCount: 0,
+          remainingPlannedChunkCount: 0,
+        ),
+        isTrue,
+      );
+    });
+
+    test('builds the initial playback queue from first and staged chunks', () {
+      final queue = kokoroBuildInitialPlaybackQueue<_FakePlaybackChunk>(
+        firstChunk: const _FakePlaybackChunk(
+          chunkId: 'chunk-1',
+          startWordIndex: 0,
+          startOffset: 0,
+        ),
+        stagedChunks: const <_FakePlaybackChunk>[
+          _FakePlaybackChunk(
+            chunkId: 'chunk-3',
+            startWordIndex: 8,
+            startOffset: 40,
+          ),
+          _FakePlaybackChunk(
+            chunkId: 'chunk-2',
+            startWordIndex: 4,
+            startOffset: 20,
+          ),
+          _FakePlaybackChunk(
+            chunkId: 'chunk-1',
+            startWordIndex: 0,
+            startOffset: 0,
+          ),
+        ],
+        chunkIdOf: (chunk) => chunk.chunkId,
+        startWordIndexOf: (chunk) => chunk.startWordIndex,
+        startOffsetOf: (chunk) => chunk.startOffset,
+      );
+
+      expect(
+        queue.map((chunk) => chunk.chunkId).toList(growable: false),
+        <String>['chunk-1', 'chunk-2', 'chunk-3'],
+      );
+    });
+
+    test('inserts ready chunks by document order instead of arrival order', () {
+      final insertIndex = kokoroPlaybackInsertIndex<_FakePlaybackChunk>(
+        activeChunks: const <_FakePlaybackChunk>[
+          _FakePlaybackChunk(
+            chunkId: 'chunk-1',
+            startWordIndex: 0,
+            startOffset: 0,
+          ),
+          _FakePlaybackChunk(
+            chunkId: 'chunk-3',
+            startWordIndex: 8,
+            startOffset: 40,
+          ),
+        ],
+        incomingChunk: const _FakePlaybackChunk(
+          chunkId: 'chunk-2',
+          startWordIndex: 4,
+          startOffset: 20,
+        ),
+        chunkIdOf: (chunk) => chunk.chunkId,
+        startWordIndexOf: (chunk) => chunk.startWordIndex,
+        startOffsetOf: (chunk) => chunk.startOffset,
+      );
+
+      expect(insertIndex, 1);
+    });
+
+    test('finds first future buffered chunk that must be replaced', () {
+      final pruneIndex = kokoroFirstFutureReplacementIndex<_FakePlaybackChunk>(
+        activeChunks: const <_FakePlaybackChunk>[
+          _FakePlaybackChunk(
+            chunkId: 'chunk-1',
+            startWordIndex: 0,
+            startOffset: 0,
+          ),
+          _FakePlaybackChunk(
+            chunkId: 'chunk-2',
+            startWordIndex: 4,
+            startOffset: 20,
+          ),
+          _FakePlaybackChunk(
+            chunkId: 'chunk-3',
+            startWordIndex: 8,
+            startOffset: 40,
+          ),
+          _FakePlaybackChunk(
+            chunkId: 'chunk-4',
+            startWordIndex: 12,
+            startOffset: 60,
+          ),
+        ],
+        currentChunkIndex: 0,
+        replacementStartWordIndex: 8,
+        startWordIndexOf: (chunk) => chunk.startWordIndex,
+      );
+
+      expect(pruneIndex, 2);
+    });
   });
+}
+
+class _FakePlaybackChunk {
+  const _FakePlaybackChunk({
+    required this.chunkId,
+    required this.startWordIndex,
+    required this.startOffset,
+  });
+
+  final String chunkId;
+  final int startWordIndex;
+  final int startOffset;
 }

--- a/test/reader_controller_playback_test.dart
+++ b/test/reader_controller_playback_test.dart
@@ -156,6 +156,137 @@ void main() {
       },
     );
 
+    test(
+      'coalesces follower selection updates while keeping audio word position current',
+      () async {
+        final engine = _FakeTtsEngine();
+        final controller = ReaderController(ttsEngine: engine);
+        addTearDown(controller.dispose);
+
+        await controller.initialize();
+        await controller.importPastedText(
+          'Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu.',
+        );
+        await controller.startPlayback();
+        engine.emitStart();
+
+        final documentId = controller.document.displayDocument.documentId;
+        final segmentId = controller.document.speechDocument.segments.first.segmentId;
+        final voiceId = controller.selectedVoice!.id;
+
+        engine.emitProgress(
+          TtsProgressUpdate(
+            startOffset: 0,
+            endOffset: 5,
+            word: 'Alpha',
+            documentId: documentId,
+            chunkId: 'chunk-1',
+            segmentId: segmentId,
+            wordStartIndex: 0,
+            wordEndIndex: 1,
+            elapsedInChunk: const Duration(milliseconds: 80),
+            chunkAudioDuration: const Duration(seconds: 4),
+            voiceId: voiceId,
+            rate: controller.currentSpeed,
+          ),
+        );
+
+        expect(controller.currentWordIndex, 1);
+        expect(controller.spokenSelection.speechEndWordIndex, 1);
+
+        engine.emitProgress(
+          TtsProgressUpdate(
+            startOffset: 6,
+            endOffset: 10,
+            word: 'beta',
+            documentId: documentId,
+            chunkId: 'chunk-1',
+            segmentId: segmentId,
+            wordStartIndex: 1,
+            wordEndIndex: 2,
+            elapsedInChunk: const Duration(milliseconds: 160),
+            chunkAudioDuration: const Duration(seconds: 4),
+            voiceId: voiceId,
+            rate: controller.currentSpeed,
+          ),
+        );
+
+        expect(controller.currentWordIndex, 2);
+        expect(
+          controller.spokenSelection.speechEndWordIndex,
+          1,
+          reason: 'Visible follower state should be allowed to lag briefly.',
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+
+        expect(controller.spokenSelection.speechEndWordIndex, 2);
+      },
+    );
+
+    test(
+      'hard-resynchronizes follower selection when drift grows too large',
+      () async {
+        final engine = _FakeTtsEngine();
+        final controller = ReaderController(ttsEngine: engine);
+        addTearDown(controller.dispose);
+
+        await controller.initialize();
+        await controller.importPastedText(
+          'one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen.',
+        );
+        await controller.startPlayback();
+        engine.emitStart();
+
+        final documentId = controller.document.displayDocument.documentId;
+        final segmentId = controller.document.speechDocument.segments.first.segmentId;
+        final voiceId = controller.selectedVoice!.id;
+
+        engine.emitProgress(
+          TtsProgressUpdate(
+            startOffset: 0,
+            endOffset: 3,
+            word: 'one',
+            documentId: documentId,
+            chunkId: 'chunk-long',
+            segmentId: segmentId,
+            wordStartIndex: 0,
+            wordEndIndex: 1,
+            elapsedInChunk: const Duration(milliseconds: 100),
+            chunkAudioDuration: const Duration(seconds: 6),
+            voiceId: voiceId,
+            rate: controller.currentSpeed,
+          ),
+        );
+
+        expect(controller.spokenSelection.speechEndWordIndex, 1);
+
+        engine.emitProgress(
+          TtsProgressUpdate(
+            startOffset: 48,
+            endOffset: 62,
+            word: 'twelve',
+            documentId: documentId,
+            chunkId: 'chunk-long',
+            segmentId: segmentId,
+            wordStartIndex: 11,
+            wordEndIndex: 12,
+            elapsedInChunk: const Duration(seconds: 3),
+            chunkAudioDuration: const Duration(seconds: 6),
+            voiceId: voiceId,
+            rate: controller.currentSpeed,
+          ),
+        );
+
+        expect(controller.currentWordIndex, 12);
+        expect(
+          controller.spokenSelection.speechEndWordIndex,
+          12,
+          reason: 'Large drift should force an immediate visible catch-up.',
+        );
+      },
+    );
+
     test('records debug playback metrics with session attribution', () async {
       final engine = _FakeTtsEngine();
       final controller = ReaderController(ttsEngine: engine);


### PR DESCRIPTION
## Summary
- make speech audio the authoritative playback channel and let highlight/follow-along coalesce and resynchronize as follower state
- harden Kokoro startup warmup, append-only queueing, ordered chunk insertion, and future-chunk replacement during recovery
- add and close the paired playback architecture/spec/test-spec leaves in progression

## Validation
- ./.flutter-sdk/bin/dart analyze lib/src/controllers/reader_controller.dart lib/src/services/kokoro_playback_coordination.dart lib/src/services/kokoro_tts_engine.dart lib/src/services/tts_engine.dart test/kokoro_playback_coordination_test.dart test/reader_controller_playback_test.dart
- ./.flutter-sdk/bin/flutter test test/kokoro_playback_coordination_test.dart test/reader_controller_playback_test.dart
- git diff --check